### PR TITLE
Avoid blink when switching to new thread

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FC, useEffect, useRef, useState } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { useSpeechRecognition } from "react-speech-recognition";
 import { v4 as uuidv4 } from "uuid";
 
@@ -24,7 +24,6 @@ interface Message {
 
 const Home: FC = () => {
   const pathname = usePathname();
-  const router = useRouter();
   const { user } = useAuth();
   const { isMessageTemporary } = useTempThread();
   const { getInput, setInput } = useThreadInput();
@@ -222,7 +221,7 @@ const Home: FC = () => {
           });
 
           await fetchBotSetTitle(userMessage.text, id);
-          router.push(`/thread/${id}`);
+          window.history.pushState({}, "", `/thread/${id}`);
           setGlobalMessages(id, [userMessage]);
         } else {
           await supabase


### PR DESCRIPTION
## Summary
- remove `useRouter` from home page since push is handled manually
- replace `router.push` with `window.history.pushState` so the UI stays on the same page while the URL updates

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881d129942c8327b7652781dc054114