### PR TITLE
Align supabase data fields with snake_case

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,7 @@ interface Message {
   text: string;
   sender: "user" | "bot";
   timestamp: number;
-  createdAt?: string;
+  created_at?: string;
 }
 
 const Home: FC = () => {
@@ -100,7 +100,7 @@ const Home: FC = () => {
         text: botResponse,
         sender: "bot",
         timestamp: Date.now(),
-        createdAt: new Date().toISOString(),
+        created_at: new Date().toISOString(),
       };
 
       setMessages((prev) => [...prev, botMessage]);
@@ -113,7 +113,7 @@ const Home: FC = () => {
           thread_id: threadId,
           text: botMessage.text,
           sender: botMessage.sender,
-          created_at: botMessage.createdAt,
+          created_at: botMessage.created_at,
           is_generated: true,
           timestamp: botMessage.timestamp,
         });
@@ -125,7 +125,7 @@ const Home: FC = () => {
             last_message: {
               text: botMessage.text,
               sender: botMessage.sender,
-              created_at: botMessage.createdAt,
+              created_at: botMessage.created_at,
             },
           })
           .eq("id", threadId);
@@ -187,7 +187,7 @@ const Home: FC = () => {
       text: input,
       sender: "user",
       timestamp,
-      createdAt: now,
+      created_at: now,
     };
 
     setInput("home", "");

--- a/src/app/thread/[threadId]/page.tsx
+++ b/src/app/thread/[threadId]/page.tsx
@@ -164,7 +164,7 @@ const Thread: FC = () => {
         text: botText,
         sender: "bot",
         timestamp: Date.now(),
-        createdAt: new Date().toISOString(),
+        created_at: new Date().toISOString(),
       };
 
       addMessageToBottom(threadId, botMessage);
@@ -174,7 +174,7 @@ const Thread: FC = () => {
         thread_id: threadId,
         text: botMessage.text,
         sender: botMessage.sender,
-        created_at: botMessage.createdAt,
+        created_at: botMessage.created_at,
         is_generated: true,
         timestamp: botMessage.timestamp,
       });
@@ -186,7 +186,7 @@ const Thread: FC = () => {
           last_message: {
             text: botMessage.text,
             sender: botMessage.sender,
-            created_at: botMessage.createdAt,
+            created_at: botMessage.created_at,
           },
         })
         .eq("id", threadId);
@@ -207,7 +207,7 @@ const Thread: FC = () => {
       text: input,
       sender: "user",
       timestamp,
-      createdAt: now,
+      created_at: now,
     };
 
     setInput(threadId, "");

--- a/src/app/thread/temp/page.tsx
+++ b/src/app/thread/temp/page.tsx
@@ -13,7 +13,7 @@ interface Message {
   text: string;
   sender: "user" | "bot";
   timestamp: number;
-  createdAt?: string;
+  created_at?: string;
 }
 
 const TempThread: FC = () => {
@@ -94,7 +94,7 @@ const TempThread: FC = () => {
         text: botResponse,
         sender: "bot",
         timestamp: Date.now(),
-        createdAt: new Date().toISOString(),
+        created_at: new Date().toISOString(),
       };
 
       setMessages((prev) => [...prev, botMessage]);
@@ -122,7 +122,7 @@ const TempThread: FC = () => {
       text: input,
       sender: "user",
       timestamp: timestamp,
-      createdAt: now,
+      created_at: now,
     };
 
     setInput("home", "");

--- a/src/components/ThreadList/index.tsx
+++ b/src/components/ThreadList/index.tsx
@@ -232,8 +232,8 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm }) => {
             const start = msg.text.toLowerCase().indexOf(lower);
             const end = start + searchTerm.length;
 
-            const createdAt = msg.createdAt
-              ? new Date(msg.createdAt).getTime() / 1000
+            const createdAt = msg.created_at
+              ? new Date(msg.created_at).getTime() / 1000
               : null;
 
             const formatted = createdAt
@@ -287,7 +287,7 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm }) => {
 
   const allItems: VirtuosoItem[] = useMemo(() => {
     const filteredThreads = loadedThreads.filter(
-      (t) => !t.isArchived && t.isDeleted !== true
+      (t) => !t.is_archived && t.is_deleted !== true
     );
 
     if (isSearchActive && hasResults) {

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -30,7 +30,7 @@ interface Message {
   text: string;
   sender: "user" | "bot";
   timestamp: number;
-  createdAt?: string;
+  created_at?: string;
 }
 
 interface MessagesLayoutProps {
@@ -77,7 +77,7 @@ const MessagesLayout: FC<MessagesLayoutProps> = ({
     let lastDate: string | null = null;
 
     messages.forEach((msg) => {
-      const date = msg.createdAt ?? new Date(msg.timestamp).toISOString();
+      const date = msg.created_at ?? new Date(msg.timestamp).toISOString();
       const formatted = formatDateGrouping(date);
 
       if (authUser && formatted !== lastDate) {

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -5,7 +5,7 @@ export interface Message {
   text: string;
   sender: "user" | "bot";
   timestamp: number;
-  createdAt?: string;
+  created_at?: string;
 }
 
 interface ThreadMessageStore {

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -1,18 +1,18 @@
 export interface Message {
   id: string;
-  senderId?: string;
+  sender_id?: string;
   text: string;
   timestamp?: { seconds: number; nanoseconds: number };
-  createdAt?: string;
+  created_at?: string;
 }
 
 export interface Thread {
   id: string;
-  userId?: string;
-  updatedAt?: { seconds: number; nanoseconds: number } | null;
+  user_id?: string;
+  updated_at?: string | null;
   title?: string;
   messages?: Message[];
-  isArchived?: boolean;
-  isDeleted?: boolean;
+  is_archived?: boolean;
+  is_deleted?: boolean;
   [key: string]: any;
 }


### PR DESCRIPTION
## Summary
- update thread list filters to snake_case columns
- switch thread and message interfaces to snake_case
- use `created_at` consistently in pages and layouts

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881e048f2e88327a97cb11cd725f7f2