### PR TITLE
Fix message logic when logged out

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,7 +43,13 @@ const Home: FC = () => {
   const hasMounted = useRef(false);
 
   useEffect(() => {
-    if (!user || isMessageTemporary) return;
+    if (!user) {
+      setMessages([]);
+      setThreadId(null);
+      return;
+    }
+
+    if (isMessageTemporary) return;
 
     if (!hasMounted.current) {
       hasMounted.current = true;
@@ -145,10 +151,11 @@ const Home: FC = () => {
     }
   };
 
-  const fetchBotSetTitle = async (
-    userMessageText: string,
-    threadId: string
-  ) => {
+const fetchBotSetTitle = async (
+  userMessageText: string,
+  threadId: string
+) => {
+    if (!user) return;
     try {
       const prompt = `Generate a short, descriptive title/subject/topic (only the title, no extra words) for the following thread message: "${userMessageText}"`;
 


### PR DESCRIPTION
## Summary
- reset local messages when user logs out so no inserts happen
- skip title generation when no user is signed in

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882da16f6d88327b7d8677764e698f8