### PR TITLE
Fix auth initialization when no session

### DIFF
--- a/src/stores/auth/useAuth.ts
+++ b/src/stores/auth/useAuth.ts
@@ -19,12 +19,17 @@ const useAuth = create<AuthState>((set) => ({
   initializeAuth: () => {
     const fetchUser = async () => {
       const {
-        data: { user },
+        data: { session },
         error,
-      } = await supabase.auth.getUser();
+      } = await supabase.auth.getSession();
 
-      if (error) console.error("Error getting user:", error);
-      set({ user, loading: false });
+      if (error) {
+        console.error("Error getting session:", error);
+        set({ user: null, loading: false });
+        return;
+      }
+
+      set({ user: session?.user ?? null, loading: false });
     };
 
     fetchUser();


### PR DESCRIPTION
## Summary
- avoid calling `getUser` when no session exists, preventing `AuthSessionMissingError`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: unable to fetch packages due to network restrictions)*


------
https://chatgpt.com/codex/tasks/task_e_6882da16f6d88327b7d8677764e698f8