### PR TITLE
Add image support for Gemini chats

### DIFF
--- a/src/app/api/gemini/route.ts
+++ b/src/app/api/gemini/route.ts
@@ -11,10 +11,10 @@ export async function OPTIONS() {
 
 export async function POST(req: Request) {
   try {
-    const { message } = await req.json();
-    if (!message)
+    const { message, image } = await req.json();
+    if (!message && !image)
       return NextResponse.json(
-        { error: "Message is required" },
+        { error: "Message or image is required" },
         { status: 400 }
       );
 
@@ -23,12 +23,28 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "API key not found" }, { status: 500 });
 
     const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`,
+      `https://generativelanguage.googleapis.com/v1/models/gemini-pro-vision:generateContent?key=${apiKey}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          contents: [{ parts: [{ text: message }] }],
+          contents: [
+            {
+              parts: [
+                ...(message ? [{ text: message }] : []),
+                ...(image
+                  ? [
+                      {
+                        inlineData: {
+                          mimeType: image.split(";")[0].split(":")[1],
+                          data: image.split(",")[1],
+                        },
+                      },
+                    ]
+                  : []),
+              ],
+            },
+          ],
         }),
       }
     );

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -1,6 +1,15 @@
-import { FC, Fragment } from "react";
-import { Flex, IconButton, Card, Tooltip, Divider } from "@chakra-ui/react";
-import { IoStop } from "react-icons/io5";
+import { FC, Fragment, useRef, useState } from "react";
+import {
+  Flex,
+  IconButton,
+  Card,
+  Tooltip,
+  Divider,
+  Image,
+  CloseButton,
+  Box,
+} from "@chakra-ui/react";
+import { IoStop, IoImageOutline } from "react-icons/io5";
 import { IoIosMic, IoMdSend } from "react-icons/io";
 import { SpeechRecognize } from "@/lib";
 import { Input } from "@themed-components";
@@ -12,7 +21,7 @@ interface MessageInputProps {
   resetTranscript: () => void;
   isFetchingResponse: boolean;
   isDisabled?: boolean;
-  sendMessage: () => void;
+  sendMessage: (image?: string | null) => void;
 }
 
 const MessageInput: FC<MessageInputProps> = ({
@@ -24,6 +33,26 @@ const MessageInput: FC<MessageInputProps> = ({
   isDisabled,
   sendMessage,
 }) => {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [image, setImage] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImage(file);
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setPreview(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const removeImage = () => {
+    setImage(null);
+    setPreview(null);
+    if (fileRef.current) fileRef.current.value = "";
+  };
   const toggleSpeechRecognition = () => {
     SpeechRecognize(isListening, resetTranscript);
   };
@@ -32,6 +61,18 @@ const MessageInput: FC<MessageInputProps> = ({
     <Fragment>
       <Divider orientation="horizontal" />
       <Card p={3} borderRadius={0} variant="surface">
+        {preview && (
+          <Box position="relative" mb={2}>
+            <Image src={preview} maxH="200px" borderRadius="md" alt="preview" />
+            <CloseButton
+              position="absolute"
+              top={1}
+              right={1}
+              size="sm"
+              onClick={removeImage}
+            />
+          </Box>
+        )}
         <Flex gap={2} justify="center" align="center">
           <Input
             value={input}
@@ -39,7 +80,7 @@ const MessageInput: FC<MessageInputProps> = ({
             onKeyDown={(e) => {
               if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();
-                sendMessage();
+                sendMessage(preview);
               }
             }}
             placeholder="Write a message..."
@@ -47,6 +88,22 @@ const MessageInput: FC<MessageInputProps> = ({
             variant="filled"
             isDisabled={isDisabled}
           />
+          <input
+            type="file"
+            accept="image/*"
+            style={{ display: "none" }}
+            ref={fileRef}
+            onChange={handleImageChange}
+          />
+          <Tooltip label="Upload image">
+            <IconButton
+              aria-label="Add Image"
+              variant="ghost"
+              icon={<IoImageOutline />}
+              onClick={() => fileRef.current?.click()}
+              isDisabled={isDisabled}
+            />
+          </Tooltip>
           <Tooltip label={isListening ? "Stop" : "Type by voice"}>
             <IconButton
               aria-label="Speech Recognition"
@@ -61,8 +118,10 @@ const MessageInput: FC<MessageInputProps> = ({
               aria-label="Send Message"
               variant="ghost"
               icon={<IoMdSend />}
-              isDisabled={isFetchingResponse || !input.trim() || isListening}
-              onClick={sendMessage}
+              isDisabled={
+                isFetchingResponse || (!input.trim() && !image) || isListening
+              }
+              onClick={() => sendMessage(preview)}
             />
           </Tooltip>
         </Flex>

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -21,6 +21,7 @@ interface Message {
   text: string;
   sender: "user" | "bot";
   timestamp: number;
+  image_url?: string;
 }
 
 interface MessageItemProps extends BoxProps {
@@ -68,34 +69,45 @@ const MessageItem: FC<MessageItemProps> = ({
           alignItems={isUser ? "flex-end" : "flex-start"}
           gap={1}
         >
-          <Box
-            p={3}
-            borderRadius="lg"
-            color={isUser ? "white" : ""}
-            bg={isUser ? `${colorScheme}.400` : "mutedSurface"}
-            maxW="max-content"
-            whiteSpace="pre-wrap"
-            wordBreak="break-word"
-            overflowWrap="anywhere"
-          >
-            <ReactMarkdown
-              components={{
-                ul: ({ children }) => (
-                  <ul style={{ paddingLeft: "20px" }}>{children}</ul>
-                ),
-                a: ({ ...props }) => (
-                  <a
-                    {...props}
-                    style={{
-                      wordBreak: "break-all",
-                      overflowWrap: "break-word",
-                    }}
-                  />
-                ),
-              }}
+          <Box>
+            {message.image_url && (
+              <Image
+                src={message.image_url}
+                maxW="xs"
+                borderRadius="md"
+                mb={2}
+                alt="Image"
+              />
+            )}
+            <Box
+              p={3}
+              borderRadius="lg"
+              color={isUser ? "white" : ""}
+              bg={isUser ? `${colorScheme}.400` : "mutedSurface"}
+              maxW="max-content"
+              whiteSpace="pre-wrap"
+              wordBreak="break-word"
+              overflowWrap="anywhere"
             >
-              {message.text}
-            </ReactMarkdown>
+              <ReactMarkdown
+                components={{
+                  ul: ({ children }) => (
+                    <ul style={{ paddingLeft: "20px" }}>{children}</ul>
+                  ),
+                  a: ({ ...props }) => (
+                    <a
+                      {...props}
+                      style={{
+                        wordBreak: "break-all",
+                        overflowWrap: "break-word",
+                      }}
+                    />
+                  ),
+                }}
+              >
+                {message.text}
+              </ReactMarkdown>
+            </Box>
           </Box>
 
           <Flex align="center" justify="center" gap={1}>

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -6,6 +6,7 @@ export interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image_url?: string;
 }
 
 interface ThreadMessageStore {

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -4,6 +4,7 @@ export interface Message {
   text: string;
   timestamp?: { seconds: number; nanoseconds: number };
   created_at?: string;
+  image_url?: string;
 }
 
 export interface Thread {


### PR DESCRIPTION
## Summary
- allow uploading images via `MessageInput`
- render message images in `MessageItem`
- extend message stores and types with `image_url`
- send images to Gemini API using `gemini-pro-vision`
- handle image responses from the API

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882ec5f7e4883278ff52e5b055ac337