### PR TITLE
Add image messaging with Gemini

### DIFF
--- a/src/app/api/gemini/route.ts
+++ b/src/app/api/gemini/route.ts
@@ -11,10 +11,10 @@ export async function OPTIONS() {
 
 export async function POST(req: Request) {
   try {
-    const { message } = await req.json();
-    if (!message)
+    const { message, image } = await req.json();
+    if (!message && !image)
       return NextResponse.json(
-        { error: "Message is required" },
+        { error: "Message or image is required" },
         { status: 400 }
       );
 
@@ -22,13 +22,21 @@ export async function POST(req: Request) {
     if (!apiKey)
       return NextResponse.json({ error: "API key not found" }, { status: 500 });
 
+    const parts: any[] = [];
+    if (message) parts.push({ text: message });
+    if (image) {
+      const [meta, data] = image.split(",");
+      const mime = meta.match(/data:(.*);base64/)[1];
+      parts.push({ inline_data: { mime_type: mime, data } });
+    }
+
     const response = await fetch(
       `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          contents: [{ parts: [{ text: message }] }],
+          contents: [{ parts }],
         }),
       }
     );

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -21,6 +21,7 @@ interface Message {
   text: string;
   sender: "user" | "bot";
   timestamp: number;
+  imageUrl?: string;
 }
 
 interface MessageItemProps extends BoxProps {
@@ -68,21 +69,29 @@ const MessageItem: FC<MessageItemProps> = ({
           alignItems={isUser ? "flex-end" : "flex-start"}
           gap={1}
         >
-          <Box
-            p={3}
-            borderRadius="lg"
-            color={isUser ? "white" : ""}
-            bg={isUser ? `${colorScheme}.400` : "mutedSurface"}
-            maxW="max-content"
-            whiteSpace="pre-wrap"
-            wordBreak="break-word"
-            overflowWrap="anywhere"
-          >
-            <ReactMarkdown
-              components={{
-                ul: ({ children }) => (
-                  <ul style={{ paddingLeft: "20px" }}>{children}</ul>
-                ),
+        <Box
+          p={3}
+          borderRadius="lg"
+          color={isUser ? "white" : ""}
+          bg={isUser ? `${colorScheme}.400` : "mutedSurface"}
+          maxW="max-content"
+          whiteSpace="pre-wrap"
+          wordBreak="break-word"
+          overflowWrap="anywhere"
+        >
+          {message.imageUrl && (
+            <Image
+              src={message.imageUrl}
+              maxW="200px"
+              mb={message.text ? 2 : 0}
+              alt="user upload"
+            />
+          )}
+          <ReactMarkdown
+            components={{
+              ul: ({ children }) => (
+                <ul style={{ paddingLeft: "20px" }}>{children}</ul>
+              ),
                 a: ({ ...props }) => (
                   <a
                     {...props}
@@ -92,11 +101,11 @@ const MessageItem: FC<MessageItemProps> = ({
                     }}
                   />
                 ),
-              }}
-            >
-              {message.text}
-            </ReactMarkdown>
-          </Box>
+            }}
+          >
+            {message.text}
+          </ReactMarkdown>
+        </Box>
 
           <Flex align="center" justify="center" gap={1}>
             {user && <Text fontSize="xs">{formattedTime}</Text>}

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -31,6 +31,7 @@ interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  imageUrl?: string;
 }
 
 interface MessagesLayoutProps {

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -6,6 +6,7 @@ export interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  imageUrl?: string;
 }
 
 interface ThreadMessageStore {

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -4,6 +4,7 @@ export interface Message {
   text: string;
   timestamp?: { seconds: number; nanoseconds: number };
   created_at?: string;
+  imageUrl?: string;
 }
 
 export interface Thread {


### PR DESCRIPTION
## Summary
- allow optional image upload in `MessageInput`
- adapt Gemini API route to handle image data
- show uploaded images in chat messages
- support image data when fetching/sending messages

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6882ec5f7e4883278ff52e5b055ac337