### PR TITLE
Add image support with Gemini

### DIFF
--- a/src/app/api/gemini/route.ts
+++ b/src/app/api/gemini/route.ts
@@ -11,8 +11,8 @@ export async function OPTIONS() {
 
 export async function POST(req: Request) {
   try {
-    const { message } = await req.json();
-    if (!message)
+    const { text, image, mimeType } = await req.json();
+    if (!text && !image)
       return NextResponse.json(
         { error: "Message is required" },
         { status: 400 }
@@ -28,7 +28,16 @@ export async function POST(req: Request) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          contents: [{ parts: [{ text: message }] }],
+          contents: [
+            {
+              parts: [
+                ...(text ? [{ text }] : []),
+                ...(image
+                  ? [{ inlineData: { data: image, mimeType: mimeType || "image/png" } }]
+                  : []),
+              ],
+            },
+          ],
         }),
       }
     );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -43,6 +43,8 @@ const NotFound = () => {
         resetTranscript={noop}
         isFetchingResponse={false}
         sendMessage={noop}
+        imagePreview={null}
+        onSelectImage={noop}
       />
     </ThreadLayout>
   );

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -1,7 +1,16 @@
-import { FC, Fragment } from "react";
-import { Flex, IconButton, Card, Tooltip, Divider } from "@chakra-ui/react";
-import { IoStop } from "react-icons/io5";
+import { FC, Fragment, useRef } from "react";
+import {
+  Flex,
+  IconButton,
+  Card,
+  Tooltip,
+  Divider,
+  Image,
+  Box,
+} from "@chakra-ui/react";
+import { IoStop, IoClose } from "react-icons/io5";
 import { IoIosMic, IoMdSend } from "react-icons/io";
+import { FiImage } from "react-icons/fi";
 import { SpeechRecognize } from "@/lib";
 import { Input } from "@themed-components";
 
@@ -13,6 +22,8 @@ interface MessageInputProps {
   isFetchingResponse: boolean;
   isDisabled?: boolean;
   sendMessage: () => void;
+  imagePreview: string | null;
+  onSelectImage: (file: File | null) => void;
 }
 
 const MessageInput: FC<MessageInputProps> = ({
@@ -23,9 +34,18 @@ const MessageInput: FC<MessageInputProps> = ({
   isFetchingResponse,
   isDisabled,
   sendMessage,
+  imagePreview,
+  onSelectImage,
 }) => {
   const toggleSpeechRecognition = () => {
     SpeechRecognize(isListening, resetTranscript);
+  };
+
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    onSelectImage(file || null);
   };
 
   return (
@@ -47,6 +67,22 @@ const MessageInput: FC<MessageInputProps> = ({
             variant="filled"
             isDisabled={isDisabled}
           />
+          <input
+            type="file"
+            accept="image/*"
+            ref={fileInputRef}
+            style={{ display: "none" }}
+            onChange={handleFileChange}
+          />
+          <Tooltip label="Attach image">
+            <IconButton
+              aria-label="Upload Image"
+              variant="ghost"
+              icon={<FiImage />}
+              onClick={() => fileInputRef.current?.click()}
+              isDisabled={isDisabled}
+            />
+          </Tooltip>
           <Tooltip label={isListening ? "Stop" : "Type by voice"}>
             <IconButton
               aria-label="Speech Recognition"
@@ -61,11 +97,28 @@ const MessageInput: FC<MessageInputProps> = ({
               aria-label="Send Message"
               variant="ghost"
               icon={<IoMdSend />}
-              isDisabled={isFetchingResponse || !input.trim() || isListening}
+              isDisabled={
+                isFetchingResponse || (!input.trim() && !imagePreview) || isListening
+              }
               onClick={sendMessage}
             />
           </Tooltip>
         </Flex>
+        {imagePreview && (
+          <Box mt={2} position="relative" maxW="200px">
+            <Image src={imagePreview} alt="preview" borderRadius="md" />
+            <IconButton
+              aria-label="Remove image"
+              icon={<IoClose />}
+              size="sm"
+              variant="ghost"
+              position="absolute"
+              top="0"
+              right="0"
+              onClick={() => onSelectImage(null)}
+            />
+          </Box>
+        )}
       </Card>
     </Fragment>
   );

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -21,6 +21,7 @@ interface Message {
   text: string;
   sender: "user" | "bot";
   timestamp: number;
+  image_url?: string;
 }
 
 interface MessageItemProps extends BoxProps {
@@ -68,35 +69,46 @@ const MessageItem: FC<MessageItemProps> = ({
           alignItems={isUser ? "flex-end" : "flex-start"}
           gap={1}
         >
-          <Box
-            p={3}
-            borderRadius="lg"
-            color={isUser ? "white" : ""}
-            bg={isUser ? `${colorScheme}.400` : "mutedSurface"}
-            maxW="max-content"
-            whiteSpace="pre-wrap"
-            wordBreak="break-word"
-            overflowWrap="anywhere"
-          >
-            <ReactMarkdown
-              components={{
-                ul: ({ children }) => (
-                  <ul style={{ paddingLeft: "20px" }}>{children}</ul>
-                ),
-                a: ({ ...props }) => (
-                  <a
-                    {...props}
-                    style={{
-                      wordBreak: "break-all",
-                      overflowWrap: "break-word",
-                    }}
-                  />
-                ),
-              }}
+          {message.image_url && (
+            <Image
+              src={message.image_url}
+              maxW="200px"
+              borderRadius="lg"
+              alt="Message image"
+            />
+          )}
+
+          {message.text && (
+            <Box
+              p={3}
+              borderRadius="lg"
+              color={isUser ? "white" : ""}
+              bg={isUser ? `${colorScheme}.400` : "mutedSurface"}
+              maxW="max-content"
+              whiteSpace="pre-wrap"
+              wordBreak="break-word"
+              overflowWrap="anywhere"
             >
-              {message.text}
-            </ReactMarkdown>
-          </Box>
+              <ReactMarkdown
+                components={{
+                  ul: ({ children }) => (
+                    <ul style={{ paddingLeft: "20px" }}>{children}</ul>
+                  ),
+                  a: ({ ...props }) => (
+                    <a
+                      {...props}
+                      style={{
+                        wordBreak: "break-all",
+                        overflowWrap: "break-word",
+                      }}
+                    />
+                  ),
+                }}
+              >
+                {message.text}
+              </ReactMarkdown>
+            </Box>
+          )}
 
           <Flex align="center" justify="center" gap={1}>
             {user && <Text fontSize="xs">{formattedTime}</Text>}

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -31,6 +31,7 @@ interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image_url?: string;
 }
 
 interface MessagesLayoutProps {

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -6,6 +6,7 @@ export interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image_url?: string;
 }
 
 interface ThreadMessageStore {

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -4,6 +4,7 @@ export interface Message {
   text: string;
   timestamp?: { seconds: number; nanoseconds: number };
   created_at?: string;
+  image_url?: string;
 }
 
 export interface Thread {


### PR DESCRIPTION
## Summary
- enable optional image uploads in `MessageInput`
- display message images in `MessageItem`
- store image URLs in message records
- update thread, home and temp thread pages for image messaging
- enhance Gemini API route to handle text and images

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68831c3b860c8327949c8cf8a7d06f55