### PR TITLE
Enable image prompts with Gemini

### DIFF
--- a/src/app/api/gemini/route.ts
+++ b/src/app/api/gemini/route.ts
@@ -11,10 +11,10 @@ export async function OPTIONS() {
 
 export async function POST(req: Request) {
   try {
-    const { message } = await req.json();
-    if (!message)
+    const { message, image } = await req.json();
+    if (!message && !image)
       return NextResponse.json(
-        { error: "Message is required" },
+        { error: "Message or image is required" },
         { status: 400 }
       );
 
@@ -22,13 +22,28 @@ export async function POST(req: Request) {
     if (!apiKey)
       return NextResponse.json({ error: "API key not found" }, { status: 500 });
 
+    const parts: any[] = [];
+    if (image) {
+      parts.push({
+        inline_data: {
+          mime_type: image.startsWith("data:image/png")
+            ? "image/png"
+            : "image/jpeg",
+          data: image.split(",")[1],
+        },
+      });
+    }
+    if (message) {
+      parts.push({ text: message });
+    }
+
     const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro-vision:generateContent?key=${apiKey}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          contents: [{ parts: [{ text: message }] }],
+          contents: [{ parts }],
         }),
       }
     );

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -1,6 +1,6 @@
 import { FC, Fragment } from "react";
 import { Flex, IconButton, Card, Tooltip, Divider } from "@chakra-ui/react";
-import { IoStop } from "react-icons/io5";
+import { IoStop, IoClose, IoImageOutline } from "react-icons/io5";
 import { IoIosMic, IoMdSend } from "react-icons/io";
 import { SpeechRecognize } from "@/lib";
 import { Input } from "@themed-components";
@@ -13,6 +13,9 @@ interface MessageInputProps {
   isFetchingResponse: boolean;
   isDisabled?: boolean;
   sendMessage: () => void;
+  imagePreview?: string | null;
+  onImageChange?: (file: File | null) => void;
+  clearImage?: () => void;
 }
 
 const MessageInput: FC<MessageInputProps> = ({
@@ -23,6 +26,9 @@ const MessageInput: FC<MessageInputProps> = ({
   isFetchingResponse,
   isDisabled,
   sendMessage,
+  imagePreview,
+  onImageChange,
+  clearImage,
 }) => {
   const toggleSpeechRecognition = () => {
     SpeechRecognize(isListening, resetTranscript);
@@ -32,6 +38,24 @@ const MessageInput: FC<MessageInputProps> = ({
     <Fragment>
       <Divider orientation="horizontal" />
       <Card p={3} borderRadius={0} variant="surface">
+        {imagePreview && (
+          <Flex mb={2} align="center" gap={2}>
+            <img
+              src={imagePreview}
+              style={{ maxHeight: "100px", borderRadius: "8px" }}
+              alt="preview"
+            />
+            {clearImage && (
+              <IconButton
+                aria-label="Remove image"
+                icon={<IoClose />}
+                size="sm"
+                variant="ghost"
+                onClick={clearImage}
+              />
+            )}
+          </Flex>
+        )}
         <Flex gap={2} justify="center" align="center">
           <Input
             value={input}
@@ -47,6 +71,29 @@ const MessageInput: FC<MessageInputProps> = ({
             variant="filled"
             isDisabled={isDisabled}
           />
+          {onImageChange && (
+            <>
+              <input
+                id="image-input"
+                type="file"
+                accept="image/*"
+                style={{ display: "none" }}
+                onChange={(e) =>
+                  onImageChange(e.target.files?.[0] ?? null)
+                }
+              />
+              <Tooltip label="Upload image">
+                <IconButton
+                  as="label"
+                  htmlFor="image-input"
+                  aria-label="Upload image"
+                  icon={<IoImageOutline />}
+                  variant="ghost"
+                  isDisabled={isDisabled}
+                />
+              </Tooltip>
+            </>
+          )}
           <Tooltip label={isListening ? "Stop" : "Type by voice"}>
             <IconButton
               aria-label="Speech Recognition"
@@ -61,7 +108,11 @@ const MessageInput: FC<MessageInputProps> = ({
               aria-label="Send Message"
               variant="ghost"
               icon={<IoMdSend />}
-              isDisabled={isFetchingResponse || !input.trim() || isListening}
+              isDisabled={
+                isFetchingResponse ||
+                (!input.trim() && !imagePreview) ||
+                isListening
+              }
               onClick={sendMessage}
             />
           </Tooltip>

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -19,6 +19,7 @@ import { useTheme } from "@/stores";
 
 interface Message {
   text: string;
+  image_url?: string;
   sender: "user" | "bot";
   timestamp: number;
 }
@@ -76,13 +77,22 @@ const MessageItem: FC<MessageItemProps> = ({
             maxW="max-content"
             whiteSpace="pre-wrap"
             wordBreak="break-word"
-            overflowWrap="anywhere"
-          >
-            <ReactMarkdown
-              components={{
-                ul: ({ children }) => (
-                  <ul style={{ paddingLeft: "20px" }}>{children}</ul>
-                ),
+          overflowWrap="anywhere"
+        >
+          {message.image_url && (
+            <Image
+              src={message.image_url}
+              alt="uploaded"
+              maxW="200px"
+              mb={2}
+              borderRadius="md"
+            />
+          )}
+          <ReactMarkdown
+            components={{
+              ul: ({ children }) => (
+                <ul style={{ paddingLeft: "20px" }}>{children}</ul>
+              ),
                 a: ({ ...props }) => (
                   <a
                     {...props}

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -28,6 +28,7 @@ import { Spinner, Progress } from "@themed-components";
 interface Message {
   id?: string;
   text: string;
+  image_url?: string;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 export interface Message {
   id?: string; // ⬅️ Was: id: any;
   text: string;
+  image_url?: string;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
@@ -52,7 +53,8 @@ const useThreadMessages = create<ThreadMessageStore>((set) => ({
         (msg) =>
           msg.timestamp === message.timestamp &&
           msg.sender === message.sender &&
-          msg.text === message.text
+          msg.text === message.text &&
+          msg.image_url === message.image_url
       );
 
       if (isDuplicate) return state;

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -2,6 +2,7 @@ export interface Message {
   id: string;
   sender_id?: string;
   text: string;
+  image_url?: string;
   timestamp?: { seconds: number; nanoseconds: number };
   created_at?: string;
 }


### PR DESCRIPTION
## Summary
- add image_url support to Message interfaces and Gemini API
- allow uploading images with preview and removal in MessageInput
- send image data in messages across pages
- display uploaded images in conversations
- tweak Gemini API route for multimodal requests

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688324a12d6883278f5bacb789e15d8a