### PR TITLE
Add image upload and Gemini vision support

### DIFF
--- a/src/app/api/gemini/route.ts
+++ b/src/app/api/gemini/route.ts
@@ -11,8 +11,8 @@ export async function OPTIONS() {
 
 export async function POST(req: Request) {
   try {
-    const { message } = await req.json();
-    if (!message)
+    const { message, image } = await req.json();
+    if (!message && !image)
       return NextResponse.json(
         { error: "Message is required" },
         { status: 400 }
@@ -22,14 +22,22 @@ export async function POST(req: Request) {
     if (!apiKey)
       return NextResponse.json({ error: "API key not found" }, { status: 500 });
 
+    const parts: any[] = [];
+    if (message) parts.push({ text: message });
+    if (image)
+      parts.push({
+        inlineData: {
+          mimeType: "image/jpeg",
+          data: image.replace(/^data:image\/[^;]+;base64,/, ""),
+        },
+      });
+
     const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro-vision:generateContent?key=${apiKey}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          contents: [{ parts: [{ text: message }] }],
-        }),
+        body: JSON.stringify({ contents: [{ parts }] }),
       }
     );
 

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -1,13 +1,23 @@
-import { FC, Fragment } from "react";
-import { Flex, IconButton, Card, Tooltip, Divider } from "@chakra-ui/react";
-import { IoStop } from "react-icons/io5";
-import { IoIosMic, IoMdSend } from "react-icons/io";
+import { FC, Fragment, useRef } from "react";
+import {
+  Flex,
+  IconButton,
+  Card,
+  Tooltip,
+  Divider,
+  Image,
+  Box,
+} from "@chakra-ui/react";
+import { IoStop, IoClose } from "react-icons/io5";
+import { IoIosMic, IoMdSend, IoMdImage } from "react-icons/io";
 import { SpeechRecognize } from "@/lib";
 import { Input } from "@themed-components";
 
 interface MessageInputProps {
   input: string;
   setInput: (value: string) => void;
+  image: string | null;
+  setImage: (value: string | null) => void;
   isListening: boolean;
   resetTranscript: () => void;
   isFetchingResponse: boolean;
@@ -18,6 +28,8 @@ interface MessageInputProps {
 const MessageInput: FC<MessageInputProps> = ({
   input,
   setInput,
+  image,
+  setImage,
   isListening,
   resetTranscript,
   isFetchingResponse,
@@ -27,6 +39,18 @@ const MessageInput: FC<MessageInputProps> = ({
   const toggleSpeechRecognition = () => {
     SpeechRecognize(isListening, resetTranscript);
   };
+
+  const fileRef = useRef<HTMLInputElement | null>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setImage(reader.result as string);
+    reader.readAsDataURL(file);
+  };
+
+  const triggerFile = () => fileRef.current?.click();
 
   return (
     <Fragment>
@@ -47,6 +71,37 @@ const MessageInput: FC<MessageInputProps> = ({
             variant="filled"
             isDisabled={isDisabled}
           />
+          {image && (
+            <Box position="relative">
+              <IconButton
+                aria-label="Remove image"
+                icon={<IoClose />}
+                size="sm"
+                variant="ghost"
+                onClick={() => setImage(null)}
+                position="absolute"
+                top={1}
+                right={1}
+              />
+              <Image src={image} maxH="100px" alt="preview" />
+            </Box>
+          )}
+          <input
+            type="file"
+            accept="image/*"
+            ref={fileRef}
+            style={{ display: "none" }}
+            onChange={handleFileChange}
+          />
+          <Tooltip label="Upload image">
+            <IconButton
+              aria-label="Upload image"
+              icon={<IoMdImage />}
+              variant="ghost"
+              onClick={triggerFile}
+              isDisabled={isDisabled}
+            />
+          </Tooltip>
           <Tooltip label={isListening ? "Stop" : "Type by voice"}>
             <IconButton
               aria-label="Speech Recognition"
@@ -61,7 +116,9 @@ const MessageInput: FC<MessageInputProps> = ({
               aria-label="Send Message"
               variant="ghost"
               icon={<IoMdSend />}
-              isDisabled={isFetchingResponse || !input.trim() || isListening}
+              isDisabled={
+                isFetchingResponse || (!input.trim() && !image) || isListening
+              }
               onClick={sendMessage}
             />
           </Tooltip>

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -19,6 +19,7 @@ import { useTheme } from "@/stores";
 
 interface Message {
   text: string;
+  image_url?: string;
   sender: "user" | "bot";
   timestamp: number;
 }
@@ -68,21 +69,24 @@ const MessageItem: FC<MessageItemProps> = ({
           alignItems={isUser ? "flex-end" : "flex-start"}
           gap={1}
         >
-          <Box
-            p={3}
-            borderRadius="lg"
-            color={isUser ? "white" : ""}
-            bg={isUser ? `${colorScheme}.400` : "mutedSurface"}
-            maxW="max-content"
-            whiteSpace="pre-wrap"
-            wordBreak="break-word"
-            overflowWrap="anywhere"
-          >
-            <ReactMarkdown
-              components={{
-                ul: ({ children }) => (
-                  <ul style={{ paddingLeft: "20px" }}>{children}</ul>
-                ),
+        <Box
+          p={3}
+          borderRadius="lg"
+          color={isUser ? "white" : ""}
+          bg={isUser ? `${colorScheme}.400` : "mutedSurface"}
+          maxW="max-content"
+          whiteSpace="pre-wrap"
+          wordBreak="break-word"
+          overflowWrap="anywhere"
+        >
+          {message.image_url && (
+            <Image src={message.image_url} maxH="200px" mb={2} alt="uploaded" />
+          )}
+          <ReactMarkdown
+            components={{
+              ul: ({ children }) => (
+                <ul style={{ paddingLeft: "20px" }}>{children}</ul>
+              ),
                 a: ({ ...props }) => (
                   <a
                     {...props}

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -28,6 +28,7 @@ import { Spinner, Progress } from "@themed-components";
 interface Message {
   id?: string;
   text: string;
+  image_url?: string;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 export interface Message {
   id?: string; // ⬅️ Was: id: any;
   text: string;
+  image_url?: string;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
@@ -52,7 +53,8 @@ const useThreadMessages = create<ThreadMessageStore>((set) => ({
         (msg) =>
           msg.timestamp === message.timestamp &&
           msg.sender === message.sender &&
-          msg.text === message.text
+          msg.text === message.text &&
+          msg.image_url === message.image_url
       );
 
       if (isDuplicate) return state;

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -2,6 +2,7 @@ export interface Message {
   id: string;
   sender_id?: string;
   text: string;
+  image_url?: string;
   timestamp?: { seconds: number; nanoseconds: number };
   created_at?: string;
 }


### PR DESCRIPTION
## Summary
- support images in message model
- add image preview and upload in message input
- display message images
- store image urls in thread messages
- handle image input/output in Gemini API route
- allow sending messages with optional images

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688324a12d6883278f5bacb789e15d8a