### PR TITLE
Enable image input and Gemini image responses

### DIFF
--- a/src/app/api/gemini/route.ts
+++ b/src/app/api/gemini/route.ts
@@ -11,10 +11,10 @@ export async function OPTIONS() {
 
 export async function POST(req: Request) {
   try {
-    const { message } = await req.json();
-    if (!message)
+    const { message, image } = await req.json();
+    if (!message && !image)
       return NextResponse.json(
-        { error: "Message is required" },
+        { error: "Message or image is required" },
         { status: 400 }
       );
 
@@ -22,13 +22,21 @@ export async function POST(req: Request) {
     if (!apiKey)
       return NextResponse.json({ error: "API key not found" }, { status: 500 });
 
+    const parts: any[] = [];
+    if (message) parts.push({ text: message });
+    if (image) {
+      const [meta, data] = image.split(",");
+      const mime = meta?.split(":")?.[1]?.split(";")?.[0] || "image/jpeg";
+      parts.push({ inline_data: { mime_type: mime, data } });
+    }
+
     const response = await fetch(
       `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          contents: [{ parts: [{ text: message }] }],
+          contents: [{ parts }],
         }),
       }
     );

--- a/src/app/thread/temp/page.tsx
+++ b/src/app/thread/temp/page.tsx
@@ -11,6 +11,7 @@ import { useAuth, useThreadInput } from "@/stores";
 
 interface Message {
   text: string;
+  image_url?: string;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
@@ -83,15 +84,26 @@ const TempThread: FC = () => {
       const res = await fetch("/api/gemini", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: userMessage.text }),
+        body: JSON.stringify({
+          message: userMessage.text,
+          image: userMessage.image_url,
+        }),
       });
 
       const data = await res.json();
-      const botResponse =
-        data?.candidates?.[0]?.content?.parts?.[0]?.text || "No response";
+      const parts = data?.candidates?.[0]?.content?.parts || [];
+      const botText = parts
+        .filter((p: any) => p.text)
+        .map((p: any) => p.text)
+        .join("");
+      const imgPart = parts.find((p: any) => p.inline_data);
+      const botImage = imgPart
+        ? `data:${imgPart.inline_data.mime_type};base64,${imgPart.inline_data.data}`
+        : undefined;
 
       const botMessage: Message = {
-        text: botResponse,
+        text: botText,
+        image_url: botImage,
         sender: "bot",
         timestamp: Date.now(),
         created_at: new Date().toISOString(),
@@ -113,13 +125,14 @@ const TempThread: FC = () => {
     }
   };
 
-  const sendMessage = async () => {
-    if (!input.trim()) return;
+  const sendMessage = async (img?: string | null) => {
+    if (!input.trim() && !img) return;
 
     const timestamp = Date.now();
     const now = new Date().toISOString();
     const userMessage: Message = {
       text: input,
+      image_url: img || undefined,
       sender: "user",
       timestamp: timestamp,
       created_at: now,

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -19,6 +19,7 @@ import { useTheme } from "@/stores";
 
 interface Message {
   text: string;
+  image_url?: string;
   sender: "user" | "bot";
   timestamp: number;
 }
@@ -96,6 +97,15 @@ const MessageItem: FC<MessageItemProps> = ({
             >
               {message.text}
             </ReactMarkdown>
+            {message.image_url && (
+              <Image
+                src={message.image_url}
+                alt="Message image"
+                mt={2}
+                maxH="200px"
+                borderRadius="md"
+              />
+            )}
           </Box>
 
           <Flex align="center" justify="center" gap={1}>

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -28,6 +28,7 @@ import { Spinner, Progress } from "@themed-components";
 interface Message {
   id?: string;
   text: string;
+  image_url?: string;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 export interface Message {
   id?: string; // ⬅️ Was: id: any;
   text: string;
+  image_url?: string;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
@@ -52,7 +53,8 @@ const useThreadMessages = create<ThreadMessageStore>((set) => ({
         (msg) =>
           msg.timestamp === message.timestamp &&
           msg.sender === message.sender &&
-          msg.text === message.text
+          msg.text === message.text &&
+          msg.image_url === message.image_url
       );
 
       if (isDuplicate) return state;

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -2,6 +2,7 @@ export interface Message {
   id: string;
   sender_id?: string;
   text: string;
+  image_url?: string;
   timestamp?: { seconds: number; nanoseconds: number };
   created_at?: string;
 }


### PR DESCRIPTION
## Summary
- support image and text in Gemini API route
- extend message types with `image_url`
- add image upload & preview to message input
- display images in messages
- handle images in thread, temp, and home pages

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688324a12d6883278f5bacb789e15d8a