### PR TITLE
Add image upload preview to MessageInput

### DIFF
--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -1,7 +1,17 @@
-import { FC, Fragment } from "react";
-import { Flex, IconButton, Card, Tooltip, Divider } from "@chakra-ui/react";
+"use client";
+
+import { FC, Fragment, useRef, useState } from "react";
+import {
+  Flex,
+  IconButton,
+  Card,
+  Tooltip,
+  Divider,
+  Box,
+  Image,
+} from "@chakra-ui/react";
 import { IoStop } from "react-icons/io5";
-import { IoIosMic, IoMdSend } from "react-icons/io";
+import { IoIosMic, IoMdSend, IoMdImage, IoMdClose } from "react-icons/io";
 import { SpeechRecognize } from "@/lib";
 import { Input } from "@themed-components";
 
@@ -24,6 +34,24 @@ const MessageInput: FC<MessageInputProps> = ({
   isDisabled,
   sendMessage,
 }) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setImagePreview(URL.createObjectURL(file));
+    }
+  };
+
+  const removeImage = () => {
+    setImagePreview(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const openFileDialog = () => fileInputRef.current?.click();
   const toggleSpeechRecognition = () => {
     SpeechRecognize(isListening, resetTranscript);
   };
@@ -32,6 +60,21 @@ const MessageInput: FC<MessageInputProps> = ({
     <Fragment>
       <Divider orientation="horizontal" />
       <Card p={3} borderRadius={0} variant="surface">
+        {imagePreview && (
+          <Box position="relative" mb={2}>
+            <Image src={imagePreview} alt="Selected image" maxH="200px" borderRadius="md" />
+            <IconButton
+              aria-label="Discard image"
+              icon={<IoMdClose />}
+              size="sm"
+              variant="ghost"
+              position="absolute"
+              top={1}
+              right={1}
+              onClick={removeImage}
+            />
+          </Box>
+        )}
         <Flex gap={2} justify="center" align="center">
           <Input
             value={input}
@@ -56,6 +99,22 @@ const MessageInput: FC<MessageInputProps> = ({
               isDisabled={isDisabled}
             />
           </Tooltip>
+          <Tooltip label="Upload image">
+            <IconButton
+              aria-label="Upload image"
+              variant="ghost"
+              icon={<IoMdImage />}
+              onClick={openFileDialog}
+              isDisabled={isDisabled}
+            />
+          </Tooltip>
+          <input
+            type="file"
+            accept="image/*"
+            ref={fileInputRef}
+            onChange={handleImageChange}
+            style={{ display: "none" }}
+          />
           <Tooltip label="Send message">
             <IconButton
               aria-label="Send Message"


### PR DESCRIPTION
## Summary
- allow image selection and preview in MessageInput
- display discard button for selected image
- enable image upload icon

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6886fff2805c8327b2617dc85487ed7b