### PR TITLE
Add image preview in MessageInput

### DIFF
--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -1,7 +1,17 @@
-import { FC, Fragment } from "react";
-import { Flex, IconButton, Card, Tooltip, Divider } from "@chakra-ui/react";
+"use client";
+
+import { FC, Fragment, useRef, useState, ChangeEvent } from "react";
+import {
+  Flex,
+  IconButton,
+  Card,
+  Tooltip,
+  Divider,
+  Image,
+  Box,
+} from "@chakra-ui/react";
 import { IoStop } from "react-icons/io5";
-import { IoIosMic, IoMdSend } from "react-icons/io";
+import { IoIosMic, IoMdSend, IoMdImage, IoMdClose } from "react-icons/io";
 import { SpeechRecognize } from "@/lib";
 import { Input } from "@themed-components";
 
@@ -28,9 +38,44 @@ const MessageInput: FC<MessageInputProps> = ({
     SpeechRecognize(isListening, resetTranscript);
   };
 
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setImagePreview(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const discardImage = () => {
+    setImagePreview(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
   return (
     <Fragment>
       <Divider orientation="horizontal" />
+      {imagePreview && (
+        <Box position="relative" maxW="200px" mb={2}>
+          <IconButton
+            aria-label="Discard image"
+            size="sm"
+            variant="ghost"
+            icon={<IoMdClose />}
+            position="absolute"
+            top={1}
+            right={1}
+            onClick={discardImage}
+          />
+          <Image src={imagePreview} alt="Image preview" borderRadius="md" />
+        </Box>
+      )}
       <Card p={3} borderRadius={0} variant="surface">
         <Flex gap={2} justify="center" align="center">
           <Input
@@ -46,6 +91,22 @@ const MessageInput: FC<MessageInputProps> = ({
             flex="1"
             variant="filled"
             isDisabled={isDisabled}
+          />
+          <Tooltip label="Upload image">
+            <IconButton
+              aria-label="Upload image"
+              variant="ghost"
+              icon={<IoMdImage />}
+              onClick={() => fileInputRef.current?.click()}
+              isDisabled={isDisabled}
+            />
+          </Tooltip>
+          <input
+            type="file"
+            accept="image/*"
+            ref={fileInputRef}
+            style={{ display: "none" }}
+            onChange={handleImageChange}
           />
           <Tooltip label={isListening ? "Stop" : "Type by voice"}>
             <IconButton


### PR DESCRIPTION
## Summary
- add client directive and state hooks for image upload in MessageInput
- show image preview with discard button
- add upload icon button to open file picker

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886fff2805c8327b2617dc85487ed7b