### PR TITLE
Add image upload preview

### DIFF
--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -1,7 +1,16 @@
-import { FC, Fragment } from "react";
-import { Flex, IconButton, Card, Tooltip, Divider } from "@chakra-ui/react";
+import { FC, Fragment, useRef, useState, useEffect } from "react";
+import {
+  Flex,
+  IconButton,
+  Card,
+  Tooltip,
+  Divider,
+  Box,
+  Image,
+} from "@chakra-ui/react";
 import { IoStop } from "react-icons/io5";
 import { IoIosMic, IoMdSend } from "react-icons/io";
+import { FiImage, FiX } from "react-icons/fi";
 import { SpeechRecognize } from "@/lib";
 import { Input } from "@themed-components";
 
@@ -28,10 +37,60 @@ const MessageInput: FC<MessageInputProps> = ({
     SpeechRecognize(isListening, resetTranscript);
   };
 
+  const [preview, setPreview] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const url = URL.createObjectURL(file);
+    setPreview(url);
+  };
+
+  const discardImage = () => {
+    if (preview) {
+      URL.revokeObjectURL(preview);
+    }
+    setPreview(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (preview) {
+        URL.revokeObjectURL(preview);
+      }
+    };
+  }, [preview]);
+
   return (
     <Fragment>
       <Divider orientation="horizontal" />
       <Card p={3} borderRadius={0} variant="surface">
+        {preview && (
+          <Box position="relative" maxW="200px" mb={3}>
+            <Image src={preview} alt="Preview" borderRadius="md" />
+            <IconButton
+              aria-label="Discard image"
+              size="sm"
+              icon={<FiX />}
+              variant="ghost"
+              position="absolute"
+              top={1}
+              right={1}
+              onClick={discardImage}
+            />
+          </Box>
+        )}
+        <input
+          type="file"
+          accept="image/*"
+          ref={fileInputRef}
+          style={{ display: "none" }}
+          onChange={handleImageChange}
+        />
         <Flex gap={2} justify="center" align="center">
           <Input
             value={input}
@@ -63,6 +122,15 @@ const MessageInput: FC<MessageInputProps> = ({
               icon={<IoMdSend />}
               isDisabled={isFetchingResponse || !input.trim() || isListening}
               onClick={sendMessage}
+            />
+          </Tooltip>
+          <Tooltip label="Upload image">
+            <IconButton
+              aria-label="Upload image"
+              variant="ghost"
+              icon={<FiImage />}
+              onClick={() => fileInputRef.current?.click()}
+              isDisabled={isDisabled}
             />
           </Tooltip>
         </Flex>


### PR DESCRIPTION
## Summary
- add image icon for uploading images in `MessageInput`
- show preview of selected image with discard option

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886fff2805c8327b2617dc85487ed7b