### PR TITLE
Add image support in temp threads

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,7 @@ import { ThreadLayout, MessagesLayout } from "@/layouts";
 
 interface Message {
   text: string;
+  image?: string | null;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;

--- a/src/app/thread/temp/page.tsx
+++ b/src/app/thread/temp/page.tsx
@@ -11,6 +11,7 @@ import { useAuth, useThreadInput } from "@/stores";
 
 interface Message {
   text: string;
+  image?: string | null;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
@@ -25,6 +26,7 @@ const TempThread: FC = () => {
   const [isFetchingResponse, setIsFetchingResponse] = useState(false);
   const [isListening, setIsListening] = useState(false);
   const [playingMessage, setPlayingMessage] = useState<string | null>(null);
+  const [image, setImage] = useState<string | null>(null);
 
   const { getInput, setInput } = useThreadInput();
   const input = getInput("home");
@@ -83,15 +85,19 @@ const TempThread: FC = () => {
       const res = await fetch("/api/gemini", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: userMessage.text }),
+        body: JSON.stringify({ message: userMessage.text, image: userMessage.image }),
       });
 
       const data = await res.json();
-      const botResponse =
-        data?.candidates?.[0]?.content?.parts?.[0]?.text || "No response";
+      const parts = data?.candidates?.[0]?.content?.parts || [];
+      const textPart = parts.find((p: any) => p.text)?.text || "";
+      const imagePart = parts.find((p: any) => p.inlineData);
 
       const botMessage: Message = {
-        text: botResponse,
+        text: textPart,
+        image: imagePart
+          ? `data:${imagePart.inlineData.mimeType};base64,${imagePart.inlineData.data}`
+          : undefined,
         sender: "bot",
         timestamp: Date.now(),
         created_at: new Date().toISOString(),
@@ -114,18 +120,20 @@ const TempThread: FC = () => {
   };
 
   const sendMessage = async () => {
-    if (!input.trim()) return;
+    if (!input.trim() && !image) return;
 
     const timestamp = Date.now();
     const now = new Date().toISOString();
     const userMessage: Message = {
       text: input,
+      image,
       sender: "user",
       timestamp: timestamp,
       created_at: now,
     };
 
     setInput("home", "");
+    setImage(null);
     setMessages((prev) => [...prev, userMessage]);
     fetchBotResponse(userMessage);
   };
@@ -151,6 +159,7 @@ const TempThread: FC = () => {
         resetTranscript={resetTranscript}
         isFetchingResponse={isFetchingResponse}
         sendMessage={sendMessage}
+        onImageChange={setImage}
       />
     </ThreadLayout>
   );

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -21,6 +21,7 @@ interface MessageInputProps {
   isFetchingResponse: boolean;
   isDisabled?: boolean;
   sendMessage: () => void;
+  onImageChange?: (image: string | null) => void;
 }
 
 const MessageInput: FC<MessageInputProps> = ({
@@ -31,6 +32,7 @@ const MessageInput: FC<MessageInputProps> = ({
   isFetchingResponse,
   isDisabled,
   sendMessage,
+  onImageChange,
 }) => {
   const toggleSpeechRecognition = () => {
     SpeechRecognize(isListening, resetTranscript);
@@ -44,6 +46,13 @@ const MessageInput: FC<MessageInputProps> = ({
     if (!file) return;
     const url = URL.createObjectURL(file);
     setPreview(url);
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      if (typeof reader.result === "string") {
+        onImageChange?.(reader.result);
+      }
+    };
+    reader.readAsDataURL(file);
   };
 
   const discardImage = () => {
@@ -51,6 +60,7 @@ const MessageInput: FC<MessageInputProps> = ({
       URL.revokeObjectURL(preview);
     }
     setPreview(null);
+    onImageChange?.(null);
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
@@ -143,7 +153,9 @@ const MessageInput: FC<MessageInputProps> = ({
               aria-label="Send Message"
               variant="ghost"
               icon={<IoMdSend />}
-              isDisabled={isFetchingResponse || !input.trim() || isListening}
+              isDisabled={
+                isFetchingResponse || (!input.trim() && !preview) || isListening
+              }
               onClick={sendMessage}
             />
           </Tooltip>

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -19,6 +19,7 @@ import { useTheme } from "@/stores";
 
 interface Message {
   text: string;
+  image?: string | null;
   sender: "user" | "bot";
   timestamp: number;
 }
@@ -96,6 +97,16 @@ const MessageItem: FC<MessageItemProps> = ({
             >
               {message.text}
             </ReactMarkdown>
+            {message.image && (
+              <Box mt={2}>
+                <Image
+                  src={message.image}
+                  alt="Message image"
+                  borderRadius="md"
+                  maxH="200px"
+                />
+              </Box>
+            )}
           </Box>
 
           <Flex align="center" justify="center" gap={1}>

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -28,6 +28,7 @@ import { Spinner, Progress } from "@themed-components";
 interface Message {
   id?: string;
   text: string;
+  image?: string | null;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 export interface Message {
   id?: string; // ⬅️ Was: id: any;
   text: string;
+  image?: string | null;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
@@ -52,7 +53,8 @@ const useThreadMessages = create<ThreadMessageStore>((set) => ({
         (msg) =>
           msg.timestamp === message.timestamp &&
           msg.sender === message.sender &&
-          msg.text === message.text
+          msg.text === message.text &&
+          msg.image === message.image
       );
 
       if (isDuplicate) return state;

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -2,6 +2,7 @@ export interface Message {
   id: string;
   sender_id?: string;
   text: string;
+  image?: string | null;
   timestamp?: { seconds: number; nanoseconds: number };
   created_at?: string;
 }


### PR DESCRIPTION
## Summary
- allow storing `image` inside threads
- add image preview and callback in `MessageInput`
- display images in `MessageItem`
- handle image data in temporary thread logic
- extend Gemini API to accept text or image prompts

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688715f21f3c8327b63bd7b9b66b0929