### PR TITLE
Add image support in temporary threads

### DIFF
--- a/src/app/thread/[threadId]/page.tsx
+++ b/src/app/thread/[threadId]/page.tsx
@@ -197,14 +197,15 @@ const Thread: FC = () => {
     }
   };
 
-  const sendMessage = async () => {
-    if (!input.trim() || !user || !threadId) return;
+  const sendMessage = async (image?: string | null) => {
+    if ((!input.trim() && !image) || !user || !threadId) return;
 
     const now = new Date().toISOString();
     const timestamp = Date.now();
 
     const userMessage: Message = {
       text: input,
+      image: image || undefined,
       sender: "user",
       timestamp,
       created_at: now,

--- a/src/app/thread/temp/page.tsx
+++ b/src/app/thread/temp/page.tsx
@@ -11,6 +11,7 @@ import { useAuth, useThreadInput } from "@/stores";
 
 interface Message {
   text: string;
+  image?: string;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
@@ -92,6 +93,7 @@ const TempThread: FC = () => {
 
       const botMessage: Message = {
         text: botResponse,
+        image: "/vercel.svg",
         sender: "bot",
         timestamp: Date.now(),
         created_at: new Date().toISOString(),
@@ -113,13 +115,14 @@ const TempThread: FC = () => {
     }
   };
 
-  const sendMessage = async () => {
-    if (!input.trim()) return;
+  const sendMessage = async (image?: string | null) => {
+    if (!input.trim() && !image) return;
 
     const timestamp = Date.now();
     const now = new Date().toISOString();
     const userMessage: Message = {
       text: input,
+      image: image || undefined,
       sender: "user",
       timestamp: timestamp,
       created_at: now,

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -19,6 +19,7 @@ import { useTheme } from "@/stores";
 
 interface Message {
   text: string;
+  image?: string;
   sender: "user" | "bot";
   timestamp: number;
 }
@@ -96,6 +97,15 @@ const MessageItem: FC<MessageItemProps> = ({
             >
               {message.text}
             </ReactMarkdown>
+            {message.image && (
+              <Image
+                src={message.image}
+                alt="Attached image"
+                mt={2}
+                borderRadius="md"
+                maxW="200px"
+              />
+            )}
           </Box>
 
           <Flex align="center" justify="center" gap={1}>

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -28,6 +28,7 @@ import { Spinner, Progress } from "@themed-components";
 interface Message {
   id?: string;
   text: string;
+  image?: string;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 export interface Message {
   id?: string; // ⬅️ Was: id: any;
   text: string;
+  image?: string;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -2,6 +2,7 @@ export interface Message {
   id: string;
   sender_id?: string;
   text: string;
+  image?: string;
   timestamp?: { seconds: number; nanoseconds: number };
   created_at?: string;
 }


### PR DESCRIPTION
## Summary
- expand `Message` types to include optional `image`
- allow `MessageInput` to attach an image and send it with the message
- display attached images in `MessageItem`
- handle images in temp thread logic and placeholder Gemini reply
- adapt thread page and store types for the new property

## Testing
- `npm install` *(fails: network blocked)*
- `npm run lint` *(fails: next not found without deps)*

------
https://chatgpt.com/codex/tasks/task_e_688719a4de588327bdf49b8cb929cb85