### PR TITLE
Add image messaging support

### DIFF
--- a/src/app/api/gemini/route.ts
+++ b/src/app/api/gemini/route.ts
@@ -11,8 +11,8 @@ export async function OPTIONS() {
 
 export async function POST(req: Request) {
   try {
-    const { message } = await req.json();
-    if (!message)
+    const { message, image } = await req.json();
+    if (!message && !image)
       return NextResponse.json(
         { error: "Message is required" },
         { status: 400 }
@@ -28,7 +28,23 @@ export async function POST(req: Request) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          contents: [{ parts: [{ text: message }] }],
+          contents: [
+            {
+              parts: [
+                ...(message ? [{ text: message }] : []),
+                ...(image
+                  ? [
+                      {
+                        inline_data: {
+                          mime_type: "image/png",
+                          data: image,
+                        },
+                      },
+                    ]
+                  : []),
+              ],
+            },
+          ],
         }),
       }
     );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -10,7 +10,7 @@ import { IoAdd } from "react-icons/io5";
 
 const NotFound = () => {
   const router = useRouter();
-  const noop = () => {};
+  const noop = (_?: any) => {};
 
   return (
     <ThreadLayout>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,7 @@ import { ThreadLayout, MessagesLayout } from "@/layouts";
 
 interface Message {
   text: string;
+  image?: string;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
@@ -177,7 +178,7 @@ const Home: FC = () => {
     }
   };
 
-  const sendMessage = async () => {
+  const sendMessage = async (_image?: string | null) => {
     if (!input.trim()) return;
 
     const timestamp = Date.now();
@@ -185,6 +186,7 @@ const Home: FC = () => {
 
     const userMessage: Message = {
       text: input,
+      image: _image,
       sender: "user",
       timestamp,
       created_at: now,

--- a/src/app/thread/[threadId]/page.tsx
+++ b/src/app/thread/[threadId]/page.tsx
@@ -197,7 +197,7 @@ const Thread: FC = () => {
     }
   };
 
-  const sendMessage = async () => {
+  const sendMessage = async (_image?: string | null) => {
     if (!input.trim() || !user || !threadId) return;
 
     const now = new Date().toISOString();
@@ -205,6 +205,7 @@ const Thread: FC = () => {
 
     const userMessage: Message = {
       text: input,
+      image: _image,
       sender: "user",
       timestamp,
       created_at: now,

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -20,7 +20,7 @@ interface MessageInputProps {
   resetTranscript: () => void;
   isFetchingResponse: boolean;
   isDisabled?: boolean;
-  sendMessage: () => void;
+  sendMessage: (image?: string | null) => void;
 }
 
 const MessageInput: FC<MessageInputProps> = ({
@@ -37,6 +37,7 @@ const MessageInput: FC<MessageInputProps> = ({
   };
 
   const [preview, setPreview] = useState<string | null>(null);
+  const [file, setFile] = useState<File | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -44,6 +45,7 @@ const MessageInput: FC<MessageInputProps> = ({
     if (!file) return;
     const url = URL.createObjectURL(file);
     setPreview(url);
+    setFile(file);
   };
 
   const discardImage = () => {
@@ -51,6 +53,7 @@ const MessageInput: FC<MessageInputProps> = ({
       URL.revokeObjectURL(preview);
     }
     setPreview(null);
+    setFile(null);
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
@@ -61,8 +64,22 @@ const MessageInput: FC<MessageInputProps> = ({
       if (preview) {
         URL.revokeObjectURL(preview);
       }
+      setFile(null);
     };
   }, [preview]);
+
+  const handleSend = async () => {
+    let base64: string | null = null;
+    if (file) {
+      base64 = await new Promise<string>((resolve) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result as string);
+        reader.readAsDataURL(file);
+      });
+    }
+    sendMessage(base64);
+    discardImage();
+  };
 
   return (
     <Fragment>
@@ -112,7 +129,7 @@ const MessageInput: FC<MessageInputProps> = ({
             onKeyDown={(e) => {
               if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();
-                sendMessage();
+                handleSend();
               }
             }}
             placeholder="Write a message..."
@@ -143,8 +160,10 @@ const MessageInput: FC<MessageInputProps> = ({
               aria-label="Send Message"
               variant="ghost"
               icon={<IoMdSend />}
-              isDisabled={isFetchingResponse || !input.trim() || isListening}
-              onClick={sendMessage}
+              isDisabled={
+                isFetchingResponse || (!input.trim() && !file) || isListening
+              }
+              onClick={handleSend}
             />
           </Tooltip>
         </Flex>

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -19,6 +19,7 @@ import { useTheme } from "@/stores";
 
 interface Message {
   text: string;
+  image?: string;
   sender: "user" | "bot";
   timestamp: number;
 }
@@ -96,6 +97,15 @@ const MessageItem: FC<MessageItemProps> = ({
             >
               {message.text}
             </ReactMarkdown>
+            {message.image && (
+              <Image
+                src={message.image}
+                alt="Message image"
+                mt={2}
+                borderRadius="md"
+                maxW="200px"
+              />
+            )}
           </Box>
 
           <Flex align="center" justify="center" gap={1}>

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -28,6 +28,7 @@ import { Spinner, Progress } from "@themed-components";
 interface Message {
   id?: string;
   text: string;
+  image?: string;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 export interface Message {
   id?: string; // ⬅️ Was: id: any;
   text: string;
+  image?: string;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
@@ -52,7 +53,8 @@ const useThreadMessages = create<ThreadMessageStore>((set) => ({
         (msg) =>
           msg.timestamp === message.timestamp &&
           msg.sender === message.sender &&
-          msg.text === message.text
+          msg.text === message.text &&
+          msg.image === message.image
       );
 
       if (isDuplicate) return state;

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -2,6 +2,7 @@ export interface Message {
   id: string;
   sender_id?: string;
   text: string;
+  image?: string;
   timestamp?: { seconds: number; nanoseconds: number };
   created_at?: string;
 }


### PR DESCRIPTION
## Summary
- extend message types and store to handle image data
- update Gemini API route to accept optional image input
- enable uploading and sending images in `MessageInput`
- show images in `MessageItem`
- add temporary thread support for sending/receiving images

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688719a4de588327bdf49b8cb929cb85