### PR TITLE
Add Supabase image upload

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import { useSpeechRecognition } from "react-speech-recognition";
 import { v4 as uuidv4 } from "uuid";
 
-import { supabase, speakText } from "@/lib";
+import { supabase, speakText, uploadChatImage } from "@/lib";
 import {
   useAuth,
   useTempThread,
@@ -181,7 +181,10 @@ const Home: FC = () => {
     }
   };
 
-  const sendMessage = async (imageBase64?: string | null) => {
+  const sendMessage = async (
+    imageBase64?: string | null,
+    imageFile?: File | null
+  ) => {
     if (!input.trim() && !imageBase64) return;
 
     const timestamp = Date.now();
@@ -252,6 +255,10 @@ const Home: FC = () => {
           created_at: now,
           timestamp,
         });
+
+        if (imageFile) {
+          await uploadChatImage(imageFile, user.id, id);
+        }
 
         fetchBotResponse(userMessage, id, imageBase64);
       } catch (error) {

--- a/src/app/thread/[threadId]/page.tsx
+++ b/src/app/thread/[threadId]/page.tsx
@@ -6,7 +6,7 @@ import { useSpeechRecognition } from "react-speech-recognition";
 
 import { ThreadLayout, MessagesLayout } from "@/layouts";
 import { MessageInput } from "@/components";
-import { supabase, speakText } from "@/lib";
+import { supabase, speakText, uploadChatImage } from "@/lib";
 import {
   useAuth,
   useThreadInput,
@@ -203,7 +203,10 @@ const Thread: FC = () => {
     }
   };
 
-  const sendMessage = async (imageBase64?: string | null) => {
+  const sendMessage = async (
+    imageBase64?: string | null,
+    imageFile?: File | null
+  ) => {
     if (!user || !threadId || (!input.trim() && !imageBase64)) return;
 
     const now = new Date().toISOString();
@@ -228,6 +231,10 @@ const Thread: FC = () => {
         created_at: now,
         timestamp,
       });
+
+      if (imageFile) {
+        await uploadChatImage(imageFile, user.id, threadId);
+      }
 
       await supabase
         .from("threads")

--- a/src/app/thread/temp/page.tsx
+++ b/src/app/thread/temp/page.tsx
@@ -77,7 +77,10 @@ const TempThread: FC = () => {
     };
   }, []);
 
-  const sendMessage = async (imageBase64?: string | null) => {
+  const sendMessage = async (
+    imageBase64?: string | null,
+    _imageFile?: File | null
+  ) => {
     if (!input.trim() && !imageBase64) return;
 
     const timestamp = Date.now();

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -20,7 +20,7 @@ interface MessageInputProps {
   resetTranscript: () => void;
   isFetchingResponse: boolean;
   isDisabled?: boolean;
-  sendMessage: (imageBase64?: string | null) => void;
+  sendMessage: (imageBase64?: string | null, imageFile?: File | null) => void;
 }
 
 const MessageInput: FC<MessageInputProps> = ({
@@ -37,6 +37,7 @@ const MessageInput: FC<MessageInputProps> = ({
   };
 
   const [preview, setPreview] = useState<string | null>(null);
+  const [imageFile, setImageFile] = useState<File | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -44,6 +45,7 @@ const MessageInput: FC<MessageInputProps> = ({
     if (!file) return;
     const url = URL.createObjectURL(file);
     setPreview(url);
+    setImageFile(file);
   };
 
   const discardImage = () => {
@@ -51,13 +53,14 @@ const MessageInput: FC<MessageInputProps> = ({
       URL.revokeObjectURL(preview);
     }
     setPreview(null);
+    setImageFile(null);
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
   };
 
   const getImageBase64 = async (): Promise<string | null> => {
-    const file = fileInputRef.current?.files?.[0];
+    const file = imageFile || fileInputRef.current?.files?.[0];
     if (!file) return null;
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
@@ -80,7 +83,7 @@ const MessageInput: FC<MessageInputProps> = ({
 
   const handleSend = async () => {
     const imageBase64 = await getImageBase64();
-    sendMessage(imageBase64);
+    sendMessage(imageBase64, imageFile);
     discardImage();
   };
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,4 @@
 export { supabase } from "./supabase/client";
 export * from "@/lib/speech/recognition";
 export * from "@/lib/speech/tts";
+export * from "./supabase/uploadImage";

--- a/src/lib/supabase/uploadImage.ts
+++ b/src/lib/supabase/uploadImage.ts
@@ -1,0 +1,28 @@
+import { supabase } from "./client";
+import { v4 as uuidv4 } from "uuid";
+
+export const uploadChatImage = async (
+  file: File,
+  userId: string,
+  threadId: string
+): Promise<string | null> => {
+  try {
+    const fileExt = file.name.split('.').pop() || 'jpg';
+    const filePath = `${userId}/chats/${threadId}/${uuidv4()}.${fileExt}`;
+
+    const { error } = await supabase.storage
+      .from("images")
+      .upload(filePath, file, { upsert: false });
+
+    if (error) {
+      console.error("Error uploading image:", error.message);
+      return null;
+    }
+
+    const { data } = supabase.storage.from("images").getPublicUrl(filePath);
+    return data.publicUrl || null;
+  } catch (err) {
+    console.error("Unexpected error uploading image:", err);
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- add `uploadChatImage` helper to upload chat images to Supabase storage
- export the new helper from the lib index
- allow `MessageInput` to pass the selected `File` when sending messages
- update message sending logic to upload the file to `images` bucket

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688726bdc1548327aeb4626c3d505f2b