### PR TITLE
Add Supabase image upload

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { useSpeechRecognition } from "react-speech-recognition";
 import { v4 as uuidv4 } from "uuid";
 
 import { supabase, speakText } from "@/lib";
+import { uploadImage } from "@/lib/supabase/uploadImage";
 import {
   useAuth,
   useTempThread,
@@ -181,13 +182,25 @@ const Home: FC = () => {
     }
   };
 
-  const sendMessage = async (imageBase64?: string | null) => {
+  const sendMessage = async (
+    imageBase64?: string | null,
+    file?: File | null
+  ) => {
     if (!input.trim() && !imageBase64) return;
 
     const timestamp = Date.now();
     const now = new Date().toISOString();
 
     const textToSend = input.trim() || "[Image sent]";
+
+    let imagePath: string | null = null;
+    if (file && user) {
+      try {
+        imagePath = await uploadImage(file, user.id);
+      } catch (e) {
+        console.error("Error uploading image:", e);
+      }
+    }
     const userMessage: Message = {
       text: textToSend,
       sender: "user",
@@ -251,6 +264,7 @@ const Home: FC = () => {
           sender: userMessage.sender,
           created_at: now,
           timestamp,
+          image_path: imagePath,
         });
 
         fetchBotResponse(userMessage, id, imageBase64);

--- a/src/app/thread/[threadId]/page.tsx
+++ b/src/app/thread/[threadId]/page.tsx
@@ -7,6 +7,7 @@ import { useSpeechRecognition } from "react-speech-recognition";
 import { ThreadLayout, MessagesLayout } from "@/layouts";
 import { MessageInput } from "@/components";
 import { supabase, speakText } from "@/lib";
+import { uploadImage } from "@/lib/supabase/uploadImage";
 import {
   useAuth,
   useThreadInput,
@@ -203,7 +204,10 @@ const Thread: FC = () => {
     }
   };
 
-  const sendMessage = async (imageBase64?: string | null) => {
+  const sendMessage = async (
+    imageBase64?: string | null,
+    file?: File | null
+  ) => {
     if (!user || !threadId || (!input.trim() && !imageBase64)) return;
 
     const now = new Date().toISOString();
@@ -216,6 +220,15 @@ const Thread: FC = () => {
       created_at: now,
     };
 
+    let imagePath: string | null = null;
+    if (file) {
+      try {
+        imagePath = await uploadImage(file, user.id);
+      } catch (e) {
+        console.error("Error uploading image:", e);
+      }
+    }
+
     setInput(threadId, "");
     addMessageToBottom(threadId, userMessage);
 
@@ -227,6 +240,7 @@ const Thread: FC = () => {
         sender: userMessage.sender,
         created_at: now,
         timestamp,
+        image_path: imagePath,
       });
 
       await supabase

--- a/src/app/thread/temp/page.tsx
+++ b/src/app/thread/temp/page.tsx
@@ -77,7 +77,10 @@ const TempThread: FC = () => {
     };
   }, []);
 
-  const sendMessage = async (imageBase64?: string | null) => {
+  const sendMessage = async (
+    imageBase64?: string | null,
+    _file?: File | null
+  ) => {
     if (!input.trim() && !imageBase64) return;
 
     const timestamp = Date.now();

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -20,7 +20,7 @@ interface MessageInputProps {
   resetTranscript: () => void;
   isFetchingResponse: boolean;
   isDisabled?: boolean;
-  sendMessage: (imageBase64?: string | null) => void;
+  sendMessage: (imageBase64?: string | null, file?: File | null) => void;
 }
 
 const MessageInput: FC<MessageInputProps> = ({
@@ -80,7 +80,8 @@ const MessageInput: FC<MessageInputProps> = ({
 
   const handleSend = async () => {
     const imageBase64 = await getImageBase64();
-    sendMessage(imageBase64);
+    const file = fileInputRef.current?.files?.[0] || null;
+    sendMessage(imageBase64, file);
     discardImage();
   };
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,4 @@
 export { supabase } from "./supabase/client";
+export { uploadImage } from "./supabase/uploadImage";
 export * from "@/lib/speech/recognition";
 export * from "@/lib/speech/tts";

--- a/src/lib/supabase/uploadImage.ts
+++ b/src/lib/supabase/uploadImage.ts
@@ -1,0 +1,24 @@
+import { v4 as uuidv4 } from "uuid";
+import { supabase } from "./client";
+
+export const uploadImage = async (
+  file: File | Blob,
+  userId: string
+): Promise<string | null> => {
+  const ext = file instanceof File && file.name.includes(".")
+    ? file.name.split(".").pop()!
+    : "jpg";
+  const fileName = `${uuidv4()}.${ext}`;
+  const filePath = `${userId}/${fileName}`;
+
+  const { error } = await supabase.storage
+    .from("images")
+    .upload(filePath, file, { upsert: true, contentType: file.type || "image/jpeg" });
+
+  if (error) {
+    console.error("Error uploading image:", error.message);
+    return null;
+  }
+
+  return filePath;
+};


### PR DESCRIPTION
## Summary
- upload selected images to the `images` bucket in Supabase
- store uploaded path when creating user messages
- support image files in `MessageInput`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_688814534f9083279d7f8649ac93881a