### PR TITLE
Upload images to Supabase storage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { useSpeechRecognition } from "react-speech-recognition";
 import { v4 as uuidv4 } from "uuid";
 
 import { supabase, speakText } from "@/lib";
+import { uploadImage } from "@/utils/uploadImage";
 import {
   useAuth,
   useTempThread,
@@ -20,6 +21,7 @@ interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image_path?: string | null;
 }
 
 const Home: FC = () => {
@@ -181,7 +183,10 @@ const Home: FC = () => {
     }
   };
 
-  const sendMessage = async (imageBase64?: string | null) => {
+  const sendMessage = async (
+    imageBase64?: string | null,
+    imageFile?: File | null
+  ) => {
     if (!input.trim() && !imageBase64) return;
 
     const timestamp = Date.now();
@@ -193,7 +198,15 @@ const Home: FC = () => {
       sender: "user",
       timestamp,
       created_at: now,
+      image_path: null,
     };
+
+    let imagePath: string | null = null;
+    if (user && !isMessageTemporary && imageFile) {
+      imagePath = await uploadImage(user.id, imageFile);
+    }
+
+    userMessage.image_path = imagePath;
 
     setInput("home", "");
     setMessages((prev) => [...prev, userMessage]);

--- a/src/app/thread/[threadId]/page.tsx
+++ b/src/app/thread/[threadId]/page.tsx
@@ -7,6 +7,7 @@ import { useSpeechRecognition } from "react-speech-recognition";
 import { ThreadLayout, MessagesLayout } from "@/layouts";
 import { MessageInput } from "@/components";
 import { supabase, speakText } from "@/lib";
+import { uploadImage } from "@/utils/uploadImage";
 import {
   useAuth,
   useThreadInput,
@@ -203,7 +204,10 @@ const Thread: FC = () => {
     }
   };
 
-  const sendMessage = async (imageBase64?: string | null) => {
+  const sendMessage = async (
+    imageBase64?: string | null,
+    imageFile?: File | null
+  ) => {
     if (!user || !threadId || (!input.trim() && !imageBase64)) return;
 
     const now = new Date().toISOString();
@@ -214,7 +218,15 @@ const Thread: FC = () => {
       sender: "user",
       timestamp,
       created_at: now,
+      image_path: null,
     };
+
+    let imagePath: string | null = null;
+    if (imageFile) {
+      imagePath = await uploadImage(user.id, imageFile);
+    }
+
+    userMessage.image_path = imagePath;
 
     setInput(threadId, "");
     addMessageToBottom(threadId, userMessage);

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -20,7 +20,7 @@ interface MessageInputProps {
   resetTranscript: () => void;
   isFetchingResponse: boolean;
   isDisabled?: boolean;
-  sendMessage: (imageBase64?: string | null) => void;
+  sendMessage: (imageBase64?: string | null, imageFile?: File | null) => void;
 }
 
 const MessageInput: FC<MessageInputProps> = ({
@@ -37,13 +37,15 @@ const MessageInput: FC<MessageInputProps> = ({
   };
 
   const [preview, setPreview] = useState<string | null>(null);
+  const [file, setFile] = useState<File | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    const url = URL.createObjectURL(file);
+    const selectedFile = e.target.files?.[0];
+    if (!selectedFile) return;
+    const url = URL.createObjectURL(selectedFile);
     setPreview(url);
+    setFile(selectedFile);
   };
 
   const discardImage = () => {
@@ -51,14 +53,15 @@ const MessageInput: FC<MessageInputProps> = ({
       URL.revokeObjectURL(preview);
     }
     setPreview(null);
+    setFile(null);
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
   };
 
   const getImageBase64 = async (): Promise<string | null> => {
-    const file = fileInputRef.current?.files?.[0];
-    if (!file) return null;
+    const fileToRead = file;
+    if (!fileToRead) return null;
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = () => {
@@ -66,7 +69,7 @@ const MessageInput: FC<MessageInputProps> = ({
         resolve(result);
       };
       reader.onerror = reject;
-      reader.readAsDataURL(file);
+      reader.readAsDataURL(fileToRead);
     });
   };
 
@@ -80,7 +83,7 @@ const MessageInput: FC<MessageInputProps> = ({
 
   const handleSend = async () => {
     const imageBase64 = await getImageBase64();
-    sendMessage(imageBase64);
+    sendMessage(imageBase64, file);
     discardImage();
   };
 

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -21,6 +21,7 @@ interface Message {
   text: string;
   sender: "user" | "bot";
   timestamp: number;
+  image_path?: string | null;
 }
 
 interface MessageItemProps extends BoxProps {

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -6,6 +6,7 @@ export interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image_path?: string | null;
 }
 
 interface ThreadMessageStore {

--- a/src/utils/uploadImage.ts
+++ b/src/utils/uploadImage.ts
@@ -1,0 +1,22 @@
+import { supabase } from "@/lib";
+import { v4 as uuidv4 } from "uuid";
+
+export const uploadImage = async (
+  userId: string,
+  file: File
+): Promise<string | null> => {
+  try {
+    const ext = file.name.split(".").pop();
+    const fileName = `${uuidv4()}.${ext}`;
+    const path = `${userId}/${fileName}`;
+    const { error } = await supabase.storage.from("images").upload(path, file);
+    if (error) {
+      console.error("Error uploading image:", error);
+      return null;
+    }
+    return path;
+  } catch (err) {
+    console.error("Error uploading image:", err);
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- support sending image file to `sendMessage`
- upload image to Supabase storage and keep its path in local message data
- add helper `uploadImage` utility
- adjust message interfaces for optional `image_path`

## Testing
- `npm run lint` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688814534f9083279d7f8649ac93881a