### PR TITLE
Add image upload support

### DIFF
--- a/src/app/api/gemini/route.ts
+++ b/src/app/api/gemini/route.ts
@@ -11,10 +11,10 @@ export async function OPTIONS() {
 
 export async function POST(req: Request) {
   try {
-    const { message } = await req.json();
-    if (!message)
+    const { message, image } = await req.json();
+    if (!message && !image)
       return NextResponse.json(
-        { error: "Message is required" },
+        { error: "Message or image is required" },
         { status: 400 }
       );
 
@@ -28,7 +28,14 @@ export async function POST(req: Request) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          contents: [{ parts: [{ text: message }] }],
+          contents: [
+            {
+              parts: [
+                ...(message ? [{ text: message }] : []),
+                ...(image ? [{ inlineData: { mimeType: image.type, data: image.data } }] : []),
+              ],
+            },
+          ],
         }),
       }
     );

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -1,7 +1,14 @@
-import { FC, Fragment } from "react";
-import { Flex, IconButton, Card, Tooltip, Divider } from "@chakra-ui/react";
+import { FC, Fragment, useRef, useState } from "react";
+import {
+  Flex,
+  IconButton,
+  Card,
+  Tooltip,
+  Divider,
+  Image,
+} from "@chakra-ui/react";
 import { IoStop } from "react-icons/io5";
-import { IoIosMic, IoMdSend } from "react-icons/io";
+import { IoIosMic, IoMdSend, IoMdImage } from "react-icons/io";
 import { SpeechRecognize } from "@/lib";
 import { Input } from "@themed-components";
 
@@ -12,7 +19,7 @@ interface MessageInputProps {
   resetTranscript: () => void;
   isFetchingResponse: boolean;
   isDisabled?: boolean;
-  sendMessage: () => void;
+  sendMessage: (file?: File | null) => void;
 }
 
 const MessageInput: FC<MessageInputProps> = ({
@@ -26,6 +33,15 @@ const MessageInput: FC<MessageInputProps> = ({
 }) => {
   const toggleSpeechRecognition = () => {
     SpeechRecognize(isListening, resetTranscript);
+  };
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleSend = () => {
+    sendMessage(file);
+    setFile(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
   };
 
   return (
@@ -56,13 +72,39 @@ const MessageInput: FC<MessageInputProps> = ({
               isDisabled={isDisabled}
             />
           </Tooltip>
+          <Tooltip label="Attach image">
+            <IconButton
+              aria-label="Attach image"
+              variant="ghost"
+              icon={<IoMdImage />}
+              onClick={() => fileInputRef.current?.click()}
+              isDisabled={isDisabled}
+            />
+          </Tooltip>
+          <input
+            type="file"
+            accept="image/*"
+            ref={fileInputRef}
+            style={{ display: "none" }}
+            onChange={(e) => setFile(e.target.files?.[0] || null)}
+          />
+          {file && (
+            <Image
+              src={URL.createObjectURL(file)}
+              alt="preview"
+              boxSize="40px"
+              objectFit="cover"
+            />
+          )}
           <Tooltip label="Send message">
             <IconButton
               aria-label="Send Message"
               variant="ghost"
               icon={<IoMdSend />}
-              isDisabled={isFetchingResponse || !input.trim() || isListening}
-              onClick={sendMessage}
+              isDisabled={
+                isFetchingResponse || (!input.trim() && !file) || isListening
+              }
+              onClick={handleSend}
             />
           </Tooltip>
         </Flex>

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -21,6 +21,7 @@ interface Message {
   text: string;
   sender: "user" | "bot";
   timestamp: number;
+  image_url?: string;
 }
 
 interface MessageItemProps extends BoxProps {
@@ -96,6 +97,16 @@ const MessageItem: FC<MessageItemProps> = ({
             >
               {message.text}
             </ReactMarkdown>
+            {message.image_url && (
+              <Box mt={2}>
+                <Image
+                  src={message.image_url}
+                  alt="Uploaded image"
+                  maxH="200px"
+                  borderRadius="md"
+                />
+              </Box>
+            )}
           </Box>
 
           <Flex align="center" justify="center" gap={1}>

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -31,6 +31,7 @@ interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image_url?: string;
 }
 
 interface MessagesLayoutProps {

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -6,6 +6,7 @@ export interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image_url?: string;
 }
 
 interface ThreadMessageStore {

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -4,6 +4,7 @@ export interface Message {
   text: string;
   timestamp?: { seconds: number; nanoseconds: number };
   created_at?: string;
+  image_url?: string;
 }
 
 export interface Thread {


### PR DESCRIPTION
## Summary
- enable image uploads in MessageInput
- update pages to send images to Gemini and save to storage
- allow storing image links in messages
- include optional image data when calling Gemini API

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688863f0be78832795ec100cfe02b787