### PR TITLE
feat: upload message images to supabase

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -181,7 +181,10 @@ const Home: FC = () => {
     }
   };
 
-  const sendMessage = async (imageBase64?: string | null) => {
+  const sendMessage = async (
+    imageBase64?: string | null,
+    imageFile?: File | null
+  ) => {
     if (!input.trim() && !imageBase64) return;
 
     const timestamp = Date.now();
@@ -252,6 +255,18 @@ const Home: FC = () => {
           created_at: now,
           timestamp,
         });
+
+        if (imageFile) {
+          const ext = imageFile.name.split(".").pop();
+          const fileName = `${timestamp}.${ext}`;
+          const filePath = `${user.id}/${id}/${fileName}`;
+          const { error: uploadError } = await supabase.storage
+            .from("messages")
+            .upload(filePath, imageFile, { upsert: false });
+          if (uploadError) {
+            console.error("Error uploading image:", uploadError);
+          }
+        }
 
         fetchBotResponse(userMessage, id, imageBase64);
       } catch (error) {

--- a/src/app/thread/[threadId]/page.tsx
+++ b/src/app/thread/[threadId]/page.tsx
@@ -203,7 +203,10 @@ const Thread: FC = () => {
     }
   };
 
-  const sendMessage = async (imageBase64?: string | null) => {
+  const sendMessage = async (
+    imageBase64?: string | null,
+    imageFile?: File | null
+  ) => {
     if (!user || !threadId || (!input.trim() && !imageBase64)) return;
 
     const now = new Date().toISOString();
@@ -228,6 +231,18 @@ const Thread: FC = () => {
         created_at: now,
         timestamp,
       });
+
+      if (imageFile) {
+        const ext = imageFile.name.split(".").pop();
+        const fileName = `${timestamp}.${ext}`;
+        const filePath = `${user.id}/${threadId}/${fileName}`;
+        const { error: uploadError } = await supabase.storage
+          .from("messages")
+          .upload(filePath, imageFile, { upsert: false });
+        if (uploadError) {
+          console.error("Error uploading image:", uploadError);
+        }
+      }
 
       await supabase
         .from("threads")

--- a/src/app/thread/temp/page.tsx
+++ b/src/app/thread/temp/page.tsx
@@ -77,7 +77,10 @@ const TempThread: FC = () => {
     };
   }, []);
 
-  const sendMessage = async (imageBase64?: string | null) => {
+  const sendMessage = async (
+    imageBase64?: string | null,
+    _imageFile?: File | null
+  ) => {
     if (!input.trim() && !imageBase64) return;
 
     const timestamp = Date.now();

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -20,7 +20,7 @@ interface MessageInputProps {
   resetTranscript: () => void;
   isFetchingResponse: boolean;
   isDisabled?: boolean;
-  sendMessage: (imageBase64?: string | null) => void;
+  sendMessage: (imageBase64?: string | null, file?: File | null) => void;
 }
 
 const MessageInput: FC<MessageInputProps> = ({
@@ -56,17 +56,17 @@ const MessageInput: FC<MessageInputProps> = ({
     }
   };
 
-  const getImageBase64 = async (): Promise<string | null> => {
-    const file = fileInputRef.current?.files?.[0];
-    if (!file) return null;
+  const getImageBase64 = async (file?: File): Promise<string | null> => {
+    const target = file ?? fileInputRef.current?.files?.[0];
+    if (!target) return null;
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = () => {
-        const result = (reader.result as string).split(",")[1]; // Strip prefix
+        const result = (reader.result as string).split(",")[1];
         resolve(result);
       };
       reader.onerror = reject;
-      reader.readAsDataURL(file);
+      reader.readAsDataURL(target);
     });
   };
 
@@ -79,8 +79,9 @@ const MessageInput: FC<MessageInputProps> = ({
   }, [preview]);
 
   const handleSend = async () => {
-    const imageBase64 = await getImageBase64();
-    sendMessage(imageBase64);
+    const file = fileInputRef.current?.files?.[0] || null;
+    const imageBase64 = await getImageBase64(file);
+    sendMessage(imageBase64, file);
     discardImage();
   };
 


### PR DESCRIPTION
## Summary
- allow MessageInput to pass image files
- upload images to Supabase storage when sending messages

## Testing
- `npm run lint` *(fails: next: not found)*
- `npx eslint .` *(fails: Cannot find package '/workspace/xeenapz/node_modules/debug/index.js')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'debug', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688abb988054832782692f3f81cb430d