### PR TITLE
feat: add image upload with supabase

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,7 @@ interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image_url?: string;
 }
 
 const Home: FC = () => {
@@ -181,22 +182,31 @@ const Home: FC = () => {
     }
   };
 
-  const sendMessage = async (imageBase64?: string | null) => {
-    if (!input.trim() && !imageBase64) return;
+  const sendMessage = async (imageFile?: File | null) => {
+    if (!input.trim() && !imageFile) return;
+
+    const fileToBase64 = (file: File): Promise<string> =>
+      new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const result = (reader.result as string).split(",")[1];
+          resolve(result);
+        };
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+      });
 
     const timestamp = Date.now();
     const now = new Date().toISOString();
+    let imageBase64: string | null = null;
+    let imageUrl: string | null = null;
+
+    if (imageFile) {
+      imageBase64 = await fileToBase64(imageFile);
+    }
 
     const textToSend = input.trim() || "[Image sent]";
-    const userMessage: Message = {
-      text: textToSend,
-      sender: "user",
-      timestamp,
-      created_at: now,
-    };
-
     setInput("home", "");
-    setMessages((prev) => [...prev, userMessage]);
 
     if (user && !isMessageTemporary) {
       try {
@@ -219,28 +229,57 @@ const Home: FC = () => {
             created_at: now,
             updated_at: now,
             last_message: {
-              text: userMessage.text,
-              sender: userMessage.sender,
+              text: textToSend,
+              sender: "user",
               created_at: now,
             },
           });
 
-          await fetchBotSetTitle(userMessage.text, id);
+          await fetchBotSetTitle(textToSend, id);
           window.history.pushState({}, "", `/thread/${id}`);
-          setGlobalMessages(id, [userMessage]);
         } else {
           await supabase
             .from("threads")
             .update({
               updated_at: now,
               last_message: {
-                text: userMessage.text,
-                sender: userMessage.sender,
+                text: textToSend,
+                sender: "user",
                 created_at: now,
               },
             })
             .eq("id", id);
+        }
 
+        if (imageFile) {
+          const ext = imageFile.name.split(".").pop();
+          const filePath = `${user.id}/${id}/${uuidv4()}.${ext}`;
+          const { error: uploadError } = await supabase.storage
+            .from("messages")
+            .upload(filePath, imageFile);
+          if (!uploadError) {
+            const { data } = supabase.storage
+              .from("messages")
+              .getPublicUrl(filePath);
+            imageUrl = data.publicUrl;
+          } else {
+            console.error("Error uploading image:", uploadError);
+          }
+        }
+
+        const userMessage: Message = {
+          text: textToSend,
+          sender: "user",
+          timestamp,
+          created_at: now,
+          ...(imageUrl ? { image_url: imageUrl } : {}),
+        };
+
+        setMessages((prev) => [...prev, userMessage]);
+
+        if (!threadId) {
+          setGlobalMessages(id, [userMessage]);
+        } else {
           addMessageToBottom(id, userMessage);
         }
 
@@ -251,6 +290,7 @@ const Home: FC = () => {
           sender: userMessage.sender,
           created_at: now,
           timestamp,
+          ...(imageUrl ? { image_url: imageUrl } : {}),
         });
 
         fetchBotResponse(userMessage, id, imageBase64);
@@ -258,6 +298,13 @@ const Home: FC = () => {
         console.error("Error sending message:", error);
       }
     } else {
+      const userMessage: Message = {
+        text: textToSend,
+        sender: "user",
+        timestamp,
+        created_at: now,
+      };
+      setMessages((prev) => [...prev, userMessage]);
       fetchBotResponse(userMessage, null, imageBase64);
     }
   };

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -20,7 +20,7 @@ interface MessageInputProps {
   resetTranscript: () => void;
   isFetchingResponse: boolean;
   isDisabled?: boolean;
-  sendMessage: (imageBase64?: string | null) => void;
+  sendMessage: (imageFile?: File | null) => void;
 }
 
 const MessageInput: FC<MessageInputProps> = ({
@@ -56,20 +56,6 @@ const MessageInput: FC<MessageInputProps> = ({
     }
   };
 
-  const getImageBase64 = async (): Promise<string | null> => {
-    const file = fileInputRef.current?.files?.[0];
-    if (!file) return null;
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => {
-        const result = (reader.result as string).split(",")[1]; // Strip prefix
-        resolve(result);
-      };
-      reader.onerror = reject;
-      reader.readAsDataURL(file);
-    });
-  };
-
   useEffect(() => {
     return () => {
       if (preview) {
@@ -79,8 +65,8 @@ const MessageInput: FC<MessageInputProps> = ({
   }, [preview]);
 
   const handleSend = async () => {
-    const imageBase64 = await getImageBase64();
-    sendMessage(imageBase64);
+    const file = fileInputRef.current?.files?.[0] || null;
+    sendMessage(file);
     discardImage();
   };
 

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -21,6 +21,7 @@ interface Message {
   text: string;
   sender: "user" | "bot";
   timestamp: number;
+  image_url?: string;
 }
 
 interface MessageItemProps extends BoxProps {
@@ -78,24 +79,35 @@ const MessageItem: FC<MessageItemProps> = ({
             wordBreak="break-word"
             overflowWrap="anywhere"
           >
-            <ReactMarkdown
-              components={{
-                ul: ({ children }) => (
-                  <ul style={{ paddingLeft: "20px" }}>{children}</ul>
-                ),
-                a: ({ ...props }) => (
-                  <a
-                    {...props}
-                    style={{
-                      wordBreak: "break-all",
-                      overflowWrap: "break-word",
-                    }}
-                  />
-                ),
-              }}
-            >
-              {message.text}
-            </ReactMarkdown>
+            {message.image_url && (
+              <Image
+                src={message.image_url}
+                alt="Uploaded image"
+                borderRadius="md"
+                mb={message.text ? 2 : 0}
+                maxW="200px"
+              />
+            )}
+            {message.text && (
+              <ReactMarkdown
+                components={{
+                  ul: ({ children }) => (
+                    <ul style={{ paddingLeft: "20px" }}>{children}</ul>
+                  ),
+                  a: ({ ...props }) => (
+                    <a
+                      {...props}
+                      style={{
+                        wordBreak: "break-all",
+                        overflowWrap: "break-word",
+                      }}
+                    />
+                  ),
+                }}
+              >
+                {message.text}
+              </ReactMarkdown>
+            )}
           </Box>
 
           <Flex align="center" justify="center" gap={1}>

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -31,6 +31,7 @@ interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image_url?: string;
 }
 
 interface MessagesLayoutProps {

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -6,6 +6,7 @@ export interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image_url?: string;
 }
 
 interface ThreadMessageStore {

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -4,6 +4,7 @@ export interface Message {
   text: string;
   timestamp?: { seconds: number; nanoseconds: number };
   created_at?: string;
+  image_url?: string;
 }
 
 export interface Thread {


### PR DESCRIPTION
## Summary
- allow uploading images in the message input
- store uploaded images in supabase storage and attach public URLs to messages
- render image attachments inside chat messages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688abb988054832782692f3f81cb430d