### PR TITLE
Store structured image attachments in messages

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -199,14 +199,7 @@ const Home: FC = () => {
     const timestamp = Date.now();
     const fileId = uuidv4();
     let id = threadId;
-
     const textToSend = input.trim() || "[Image sent]";
-    const userMessage: Message = {
-      text: textToSend,
-      sender: "user",
-      timestamp,
-      created_at: now,
-    };
 
     // Create thread if needed
     if (user && !id && !isMessageTemporary) {
@@ -226,12 +219,7 @@ const Home: FC = () => {
       });
 
       window.history.pushState({}, "", `/thread/${id}`);
-      setGlobalMessages(id, [userMessage]);
     }
-
-    setInput("home", "");
-    setMessages((prev) => [...prev, userMessage]);
-    discardImage();
 
     // Upload image and attach public URL
     let imageData: Message["image"] | undefined;
@@ -264,6 +252,23 @@ const Home: FC = () => {
       }
     }
 
+    const userMessage: Message = {
+      text: textToSend,
+      sender: "user",
+      timestamp,
+      created_at: now,
+      image: imageData,
+    };
+
+    // set global messages if thread was just created
+    if (user && id && id !== threadId && !isMessageTemporary) {
+      setGlobalMessages(id, [userMessage]);
+    }
+
+    setInput("home", "");
+    setMessages((prev) => [...prev, userMessage]);
+    discardImage();
+
     // Insert message
     if (user && !isMessageTemporary && id) {
       try {
@@ -279,7 +284,7 @@ const Home: FC = () => {
           })
           .eq("id", id);
 
-        addMessageToBottom(id, { ...userMessage, image: imageData } as any);
+        addMessageToBottom(id, userMessage as any);
 
         await supabase.from("messages").insert({
           user_id: user.id,

--- a/src/app/thread/[threadId]/page.tsx
+++ b/src/app/thread/[threadId]/page.tsx
@@ -236,18 +236,7 @@ const Thread: FC = () => {
     const timestamp = Date.now();
     const fileId = uuidv4();
 
-    const userMessage: Message = {
-      text: input.trim() || "[Image sent]",
-      sender: "user",
-      timestamp,
-      created_at: now,
-    };
-
-    setInput(threadId, "");
-    addMessageToBottom(threadId, userMessage);
-    discardImage();
-
-    // upload image to storage
+    let imageData: Message["image"] | undefined;
     if (base64Image) {
       try {
         const binary = atob(base64Image);
@@ -261,11 +250,33 @@ const Thread: FC = () => {
         });
 
         const path = `${user.id}/${threadId}/${fileId}.png`;
-        await supabase.storage.from("messages").upload(path, file);
+        const uploadRes = await supabase.storage
+          .from("messages")
+          .upload(path, file);
+
+        if (!uploadRes.error) {
+          imageData = {
+            id: fileId,
+            path,
+            url: `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/messages/${path}`,
+          };
+        }
       } catch (err) {
         console.error("Image upload failed:", err);
       }
     }
+
+    const userMessage: Message = {
+      text: input.trim() || "[Image sent]",
+      sender: "user",
+      timestamp,
+      created_at: now,
+      image: imageData,
+    };
+
+    setInput(threadId, "");
+    addMessageToBottom(threadId, userMessage);
+    discardImage();
 
     try {
       await supabase.from("messages").insert({
@@ -275,6 +286,7 @@ const Thread: FC = () => {
         sender: userMessage.sender,
         created_at: now,
         timestamp,
+        image: imageData ?? null,
       });
 
       await supabase

--- a/src/app/thread/temp/page.tsx
+++ b/src/app/thread/temp/page.tsx
@@ -14,6 +14,11 @@ interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image?: {
+    id: string;
+    path: string;
+    url: string;
+  } | null;
 }
 
 const TempThread: FC = () => {

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -21,6 +21,11 @@ interface Message {
   text: string;
   sender: "user" | "bot";
   timestamp: number;
+  image?: {
+    id: string;
+    path: string;
+    url: string;
+  } | null;
 }
 
 interface MessageItemProps extends BoxProps {
@@ -78,6 +83,15 @@ const MessageItem: FC<MessageItemProps> = ({
             wordBreak="break-word"
             overflowWrap="anywhere"
           >
+            {message.image?.url && (
+              <Image
+                src={message.image.url}
+                alt="Attached image"
+                borderRadius="md"
+                maxH="200px"
+                mb={message.text ? 2 : 0}
+              />
+            )}
             <ReactMarkdown
               components={{
                 ul: ({ children }) => (

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -31,6 +31,11 @@ interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image?: {
+    id: string;
+    path: string;
+    url: string;
+  } | null;
 }
 
 interface MessagesLayoutProps {

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -6,6 +6,11 @@ export interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image?: {
+    id: string;
+    path: string;
+    url: string;
+  } | null;
 }
 
 interface ThreadMessageStore {

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -4,6 +4,11 @@ export interface Message {
   text: string;
   timestamp?: { seconds: number; nanoseconds: number };
   created_at?: string;
+  image?: {
+    id: string;
+    path: string;
+    url: string;
+  } | null;
 }
 
 export interface Thread {


### PR DESCRIPTION
## Summary
- Store message images in Supabase using a structured object containing id, path, and url
- Support image attachments in threaded conversations and display them in the UI
- Extend message types across the app to include optional image metadata

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c18af3b288327a197a750dc47fe17