### PR TITLE
feat: persist message image metadata

### DIFF
--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -21,6 +21,11 @@ interface Message {
   text: string;
   sender: "user" | "bot";
   timestamp: number;
+  image?: {
+    id: string;
+    path: string;
+    url: string;
+  };
 }
 
 interface MessageItemProps extends BoxProps {
@@ -78,6 +83,15 @@ const MessageItem: FC<MessageItemProps> = ({
             wordBreak="break-word"
             overflowWrap="anywhere"
           >
+            {message.image && (
+              <Image
+                src={message.image.url}
+                alt="Message image"
+                mb={2}
+                borderRadius="md"
+                maxW="200px"
+              />
+            )}
             <ReactMarkdown
               components={{
                 ul: ({ children }) => (

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -31,6 +31,11 @@ interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image?: {
+    id: string;
+    path: string;
+    url: string;
+  };
 }
 
 interface MessagesLayoutProps {

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -6,6 +6,11 @@ export interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image?: {
+    id: string;
+    path: string;
+    url: string;
+  };
 }
 
 interface ThreadMessageStore {

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -4,6 +4,11 @@ export interface Message {
   text: string;
   timestamp?: { seconds: number; nanoseconds: number };
   created_at?: string;
+  image?: {
+    id: string;
+    path: string;
+    url: string;
+  };
 }
 
 export interface Thread {


### PR DESCRIPTION
## Summary
- save uploaded image metadata to messages on home and thread pages
- support message image in thread message store and message components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688c18af3b288327a197a750dc47fe17