### PR TITLE
feat: store image metadata in messages

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -279,7 +279,7 @@ const Home: FC = () => {
           })
           .eq("id", id);
 
-        addMessageToBottom(id, { ...userMessage, image: imageData } as any);
+        addMessageToBottom(id, { ...userMessage, image: imageData });
 
         await supabase.from("messages").insert({
           user_id: user.id,

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -21,6 +21,11 @@ interface Message {
   text: string;
   sender: "user" | "bot";
   timestamp: number;
+  image?: {
+    id: string;
+    path: string;
+    url: string;
+  };
 }
 
 interface MessageItemProps extends BoxProps {
@@ -96,6 +101,15 @@ const MessageItem: FC<MessageItemProps> = ({
             >
               {message.text}
             </ReactMarkdown>
+            {message.image && (
+              <Image
+                mt={2}
+                src={message.image.url}
+                alt="Attached image"
+                borderRadius="md"
+                maxH="300px"
+              />
+            )}
           </Box>
 
           <Flex align="center" justify="center" gap={1}>

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -31,6 +31,11 @@ interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image?: {
+    id: string;
+    path: string;
+    url: string;
+  };
 }
 
 interface MessagesLayoutProps {

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -6,6 +6,11 @@ export interface Message {
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
+  image?: {
+    id: string;
+    path: string;
+    url: string;
+  };
 }
 
 interface ThreadMessageStore {

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -4,6 +4,11 @@ export interface Message {
   text: string;
   timestamp?: { seconds: number; nanoseconds: number };
   created_at?: string;
+  image?: {
+    id: string;
+    path: string;
+    url: string;
+  };
 }
 
 export interface Thread {


### PR DESCRIPTION
## Summary
- persist image metadata alongside text messages on home and thread pages
- extend message types and UI to handle optional image attachments

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688c18af3b288327a197a750dc47fe17