### PR TITLE
Allow image-only messages and hide empty bubbles

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ import { MessageInput } from "@/components";
 import { ThreadLayout, MessagesLayout } from "@/layouts";
 
 interface Message {
-  text: string;
+  text: string | null;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;
@@ -24,7 +24,7 @@ interface Message {
     id: string;
     path: string;
     url: string;
-  };
+  } | null;
 }
 
 const Home: FC = () => {
@@ -201,7 +201,7 @@ const Home: FC = () => {
     let id = threadId;
     let isNewThread = false;
 
-    const textToSend = input.trim() || "[Image sent]";
+    const textToSend = input.trim() || null;
     const userMessage: Message = {
       text: textToSend,
       sender: "user",
@@ -297,7 +297,7 @@ const Home: FC = () => {
           image: imageData ?? null,
         });
 
-        await fetchBotSetTitle(userMessage.text, id);
+        await fetchBotSetTitle(userMessage.text ?? "", id);
         fetchBotResponse(userMessage, id, base64Image);
       } catch (error) {
         console.error("Error sending message:", error);

--- a/src/app/thread/[threadId]/page.tsx
+++ b/src/app/thread/[threadId]/page.tsx
@@ -237,7 +237,7 @@ const Thread: FC = () => {
     const fileId = uuidv4();
 
     const userMessage: Message = {
-      text: input.trim() || "[Image sent]",
+      text: input.trim() || null,
       sender: "user",
       timestamp,
       created_at: now,

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -18,7 +18,7 @@ import {
 import { useTheme } from "@/stores";
 
 interface Message {
-  text: string;
+  text: string | null;
   sender: "user" | "bot";
   timestamp: number;
   image?: {
@@ -57,6 +57,8 @@ const MessageItem: FC<MessageItemProps> = ({
 
   const { colorScheme } = useTheme();
 
+  if (!message.text && !message.image) return null;
+
   return (
     <Flex
       direction="column"
@@ -83,39 +85,41 @@ const MessageItem: FC<MessageItemProps> = ({
               rounded="md"
             />
           )}
-          <Box
-            p={3}
-            borderRadius="lg"
-            color={isUser ? "white" : ""}
-            bg={isUser ? `${colorScheme}.400` : "mutedSurface"}
-            maxW="max-content"
-            whiteSpace="pre-wrap"
-            wordBreak="break-word"
-            overflowWrap="anywhere"
-          >
-            <ReactMarkdown
-              components={{
-                ul: ({ children }) => (
-                  <ul style={{ paddingLeft: "20px" }}>{children}</ul>
-                ),
-                a: ({ ...props }) => (
-                  <a
-                    {...props}
-                    style={{
-                      wordBreak: "break-all",
-                      overflowWrap: "break-word",
-                    }}
-                  />
-                ),
-              }}
+          {message.text && (
+            <Box
+              p={3}
+              borderRadius="lg"
+              color={isUser ? "white" : ""}
+              bg={isUser ? `${colorScheme}.400` : "mutedSurface"}
+              maxW="max-content"
+              whiteSpace="pre-wrap"
+              wordBreak="break-word"
+              overflowWrap="anywhere"
             >
-              {message.text}
-            </ReactMarkdown>
-          </Box>
+              <ReactMarkdown
+                components={{
+                  ul: ({ children }) => (
+                    <ul style={{ paddingLeft: "20px" }}>{children}</ul>
+                  ),
+                  a: ({ ...props }) => (
+                    <a
+                      {...props}
+                      style={{
+                        wordBreak: "break-all",
+                        overflowWrap: "break-word",
+                      }}
+                    />
+                  ),
+                }}
+              >
+                {message.text}
+              </ReactMarkdown>
+            </Box>
+          )}
 
           <Flex align="center" justify="center" gap={1}>
             {user && <Text fontSize="xs">{formattedTime}</Text>}
-            {!isUser && (
+            {!isUser && message.text && (
               <Tooltip
                 label={playingMessage === message.text ? "Stop" : "Read aloud"}
               >
@@ -131,7 +135,7 @@ const MessageItem: FC<MessageItemProps> = ({
                   variant="ghost"
                   size="xs"
                   onClick={() =>
-                    speakText(message.text, playingMessage, setPlayingMessage)
+                    speakText(message.text!, playingMessage, setPlayingMessage)
                   }
                 />
               </Tooltip>

--- a/src/components/ThreadList/index.tsx
+++ b/src/components/ThreadList/index.tsx
@@ -228,7 +228,7 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm }) => {
     if (searchTerm) {
       loadedThreads.forEach((thread) => {
         thread.messages?.forEach((msg) => {
-          if (msg.text.toLowerCase().includes(lower)) {
+          if (msg.text && msg.text.toLowerCase().includes(lower)) {
             const start = msg.text.toLowerCase().indexOf(lower);
             const end = start + searchTerm.length;
 

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -27,7 +27,7 @@ import { Spinner, Progress } from "@themed-components";
 
 interface Message {
   id?: string;
-  text: string;
+  text: string | null;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 
 export interface Message {
   id?: string; // ⬅️ Was: id: any;
-  text: string;
+  text: string | null;
   sender: "user" | "bot";
   timestamp: number;
   created_at?: string;

--- a/src/types/thread.ts
+++ b/src/types/thread.ts
@@ -1,7 +1,7 @@
 export interface Message {
   id: string;
   sender_id?: string;
-  text: string;
+  text: string | null;
   timestamp?: { seconds: number; nanoseconds: number };
   created_at?: string;
   image?: {


### PR DESCRIPTION
## Summary
- support sending messages with `null` text so image-only posts are allowed
- hide text bubble and speaker controls when message has no text
- update search and types to account for nullable message text

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_688c390bc4cc8327936444c3cf35acd3