### PR TITLE
Delete images from storage when removing threads

### DIFF
--- a/src/components/ThreadItem/index.tsx
+++ b/src/components/ThreadItem/index.tsx
@@ -92,6 +92,24 @@ const ThreadItem: FC<ThreadItemProps> = ({
         .eq("user_id", user.id)
         .eq("thread_id", thread.id);
 
+      const { data: files, error: listError } = await supabase.storage
+        .from("messages")
+        .list(`${user.id}/${thread.id}`);
+
+      if (listError) {
+        console.error("Failed to list images:", listError);
+      } else if (files && files.length > 0) {
+        const paths = files.map(
+          (file) => `${user.id}/${thread.id}/${file.name}`,
+        );
+        const { error: removeError } = await supabase.storage
+          .from("messages")
+          .remove(paths);
+        if (removeError) {
+          console.error("Failed to remove images:", removeError);
+        }
+      }
+
       await supabase
         .from("threads")
         .delete()


### PR DESCRIPTION
## Summary
- Clean up message images from storage when a thread is deleted.

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_688c60a174e08327a22067c6e3c4e3d1