### PR TITLE
fix: clear image preview on send

### DIFF
--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -64,8 +64,12 @@ const MessageInput: FC<MessageInputProps> = ({
   }, [preview]);
 
   const handleSend = async () => {
-    await sendMessage();
-    handleDiscard();
+    const sendPromise = sendMessage();
+    if (preview) {
+      URL.revokeObjectURL(preview);
+      setPreview(null);
+    }
+    await sendPromise;
   };
 
   return (


### PR DESCRIPTION
## Summary
- remove image preview immediately after sending a message

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892a3551bf883278bc4c7695fe0ba96