### PR TITLE
feat: enable drag and drop image uploads

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -13,6 +13,24 @@ const NotFound = () => {
   const noop = () => {};
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files?.[0];
+    if (!file || !file.type.startsWith("image/")) return;
+
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    if (fileInputRef.current) {
+      fileInputRef.current.files = dt.files;
+      const event = new Event("change", { bubbles: true });
+      fileInputRef.current.dispatchEvent(event);
+    }
+  };
+
   return (
     <ThreadLayout>
       <Flex
@@ -47,6 +65,8 @@ const NotFound = () => {
         sendMessage={noop}
         fileInputRef={fileInputRef}
         discardImage={noop}
+        handleDrop={handleDrop}
+        handleDragOver={handleDragOver}
       />
     </ThreadLayout>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,6 +52,24 @@ const Home: FC = () => {
     if (fileInputRef.current) fileInputRef.current.value = "";
   };
 
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files?.[0];
+    if (!file || !file.type.startsWith("image/")) return;
+
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    if (fileInputRef.current) {
+      fileInputRef.current.files = dt.files;
+      const event = new Event("change", { bubbles: true });
+      fileInputRef.current.dispatchEvent(event);
+    }
+  };
+
   const getImageBase64 = async (): Promise<string | null> => {
     const file = fileInputRef.current?.files?.[0];
     if (!file) return null;
@@ -321,6 +339,8 @@ const Home: FC = () => {
         playingMessage={playingMessage}
         setPlayingMessage={setPlayingMessage}
         messagesEndRef={messagesEndRef}
+        handleDrop={handleDrop}
+        handleDragOver={handleDragOver}
       />
       <MessageInput
         input={input}
@@ -331,6 +351,8 @@ const Home: FC = () => {
         sendMessage={sendMessage}
         fileInputRef={fileInputRef}
         discardImage={discardImage}
+        handleDrop={handleDrop}
+        handleDragOver={handleDragOver}
       />
     </ThreadLayout>
   );

--- a/src/app/thread/[threadId]/page.tsx
+++ b/src/app/thread/[threadId]/page.tsx
@@ -53,6 +53,24 @@ const Thread: FC = () => {
     }
   };
 
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files?.[0];
+    if (!file || !file.type.startsWith("image/")) return;
+
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    if (fileInputRef.current) {
+      fileInputRef.current.files = dt.files;
+      const event = new Event("change", { bubbles: true });
+      fileInputRef.current.dispatchEvent(event);
+    }
+  };
+
   const getImageBase64 = async (): Promise<string | null> => {
     const file = fileInputRef.current?.files?.[0];
     if (!file || !file.type.startsWith("image/")) return null;
@@ -328,6 +346,8 @@ const Thread: FC = () => {
         messagesEndRef={messagesEndRef}
         onLoadMore={handleLoadMessages}
         isLoading={loadingMessages}
+        handleDrop={handleDrop}
+        handleDragOver={handleDragOver}
       />
       <MessageInput
         input={input}
@@ -338,6 +358,8 @@ const Thread: FC = () => {
         sendMessage={sendMessage}
         fileInputRef={fileInputRef}
         discardImage={discardImage}
+        handleDrop={handleDrop}
+        handleDragOver={handleDragOver}
       />
     </ThreadLayout>
   );

--- a/src/app/thread/temp/page.tsx
+++ b/src/app/thread/temp/page.tsx
@@ -171,6 +171,24 @@ const TempThread: FC = () => {
 
   const isBlocked = !user && !loading;
 
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files?.[0];
+    if (!file || !file.type.startsWith("image/")) return;
+
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    if (fileInputRef.current) {
+      fileInputRef.current.files = dt.files;
+      const event = new Event("change", { bubbles: true });
+      fileInputRef.current.dispatchEvent(event);
+    }
+  };
+
   return (
     <ThreadLayout>
       <MessagesLayout
@@ -182,6 +200,8 @@ const TempThread: FC = () => {
         setPlayingMessage={setPlayingMessage}
         messagesEndRef={messagesEndRef}
         emptyStateText="Temporary Thread"
+        handleDrop={handleDrop}
+        handleDragOver={handleDragOver}
       />
       <MessageInput
         input={isBlocked ? "" : input}
@@ -192,6 +212,8 @@ const TempThread: FC = () => {
         sendMessage={sendMessage}
         fileInputRef={fileInputRef}
         discardImage={discardImage}
+        handleDrop={handleDrop}
+        handleDragOver={handleDragOver}
       />
     </ThreadLayout>
   );

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -23,6 +23,8 @@ interface MessageInputProps {
   sendMessage: () => void;
   fileInputRef: RefObject<HTMLInputElement | null>;
   discardImage: () => void;
+  handleDrop: (e: React.DragEvent<HTMLDivElement>) => void;
+  handleDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
 }
 
 const MessageInput: FC<MessageInputProps> = ({
@@ -35,6 +37,8 @@ const MessageInput: FC<MessageInputProps> = ({
   sendMessage,
   fileInputRef,
   discardImage,
+  handleDrop,
+  handleDragOver,
 }) => {
   const toggleSpeechRecognition = () => {
     SpeechRecognize(isListening, resetTranscript);
@@ -75,7 +79,13 @@ const MessageInput: FC<MessageInputProps> = ({
   return (
     <Fragment>
       <Divider orientation="horizontal" />
-      <Card p={3} borderRadius={0} variant="surface">
+      <Card
+        p={3}
+        borderRadius={0}
+        variant="surface"
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+      >
         {preview && (
           <Box position="relative" maxW="100px" mb={3}>
             <Image src={preview} alt="Preview" borderRadius="md" />

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -53,6 +53,8 @@ interface MessagesLayoutProps {
   isLoading?: boolean;
   emptyStateText?: string;
   onLoadMore?: () => Promise<void>;
+  handleDrop: (e: React.DragEvent<HTMLDivElement>) => void;
+  handleDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
 }
 
 const MessagesLayout: FC<MessagesLayoutProps> = ({
@@ -66,6 +68,8 @@ const MessagesLayout: FC<MessagesLayoutProps> = ({
   isLoading = false,
   emptyStateText = "Hello, what can I help with?",
   onLoadMore,
+  handleDrop,
+  handleDragOver,
 }) => {
   const { user: authUser } = useAuth();
   const virtuosoRef = useRef<VirtuosoHandle>(null);
@@ -142,7 +146,12 @@ const MessagesLayout: FC<MessagesLayoutProps> = ({
   }
 
   return (
-    <Box flex="1" overflow="hidden">
+    <Box
+      flex="1"
+      overflow="hidden"
+      onDrop={handleDrop}
+      onDragOver={handleDragOver}
+    >
       {messages.length === 0 ? (
         <VStack height="100%">
           <Flex flex="1" justify="center" align="center">


### PR DESCRIPTION
## Summary
- support image drag and drop in MessageInput
- enable MessagesLayout to forward dropped files
- wire drag events through pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892ae85c18083279d086413524a0b62