### PR TITLE
feat: add drag and drop upload

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import {
   useThreadMessages,
 } from "@/stores";
 import { MessageInput } from "@/components";
+import type { MessageInputHandle } from "@/components/MessageInput";
 import { ThreadLayout, MessagesLayout } from "@/layouts";
 
 interface Message {
@@ -47,6 +48,7 @@ const Home: FC = () => {
   const prevTranscriptRef = useRef("");
   const hasMounted = useRef(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const messageInputRef = useRef<MessageInputHandle | null>(null);
 
   const discardImage = () => {
     if (fileInputRef.current) fileInputRef.current.value = "";
@@ -312,7 +314,9 @@ const Home: FC = () => {
   };
 
   return (
-    <ThreadLayout>
+    <ThreadLayout
+      onFileDrop={(file) => messageInputRef.current?.handleFile(file)}
+    >
       <MessagesLayout
         messages={messages}
         isFetchingResponse={isFetchingResponse}
@@ -323,6 +327,7 @@ const Home: FC = () => {
         messagesEndRef={messagesEndRef}
       />
       <MessageInput
+        ref={messageInputRef}
         input={input}
         setInput={(val) => setInput("home", val)}
         isListening={isListening}

--- a/src/app/thread/[threadId]/page.tsx
+++ b/src/app/thread/[threadId]/page.tsx
@@ -7,6 +7,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import { ThreadLayout, MessagesLayout } from "@/layouts";
 import { MessageInput } from "@/components";
+import type { MessageInputHandle } from "@/components/MessageInput";
 import { supabase, speakText } from "@/lib";
 import {
   useAuth,
@@ -46,6 +47,7 @@ const Thread: FC = () => {
   const prevTranscriptRef = useRef("");
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const messageInputRef = useRef<MessageInputHandle | null>(null);
 
   const discardImage = () => {
     if (fileInputRef.current) {
@@ -317,7 +319,9 @@ const Thread: FC = () => {
   if (loading) return null;
 
   return (
-    <ThreadLayout>
+    <ThreadLayout
+      onFileDrop={(file) => messageInputRef.current?.handleFile(file)}
+    >
       <MessagesLayout
         messages={messages}
         isFetchingResponse={isFetchingResponse}
@@ -330,6 +334,7 @@ const Thread: FC = () => {
         isLoading={loadingMessages}
       />
       <MessageInput
+        ref={messageInputRef}
         input={input}
         setInput={(val) => setInput(threadId || "home", val)}
         isListening={isListening}

--- a/src/app/thread/temp/page.tsx
+++ b/src/app/thread/temp/page.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useSpeechRecognition } from "react-speech-recognition";
 
 import { MessageInput } from "@/components";
+import type { MessageInputHandle } from "@/components/MessageInput";
 import { ThreadLayout, MessagesLayout } from "@/layouts";
 import { speakText } from "@/lib";
 import { useAuth, useThreadInput } from "@/stores";
@@ -41,6 +42,7 @@ const TempThread: FC = () => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const hasMounted = useRef(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const messageInputRef = useRef<MessageInputHandle | null>(null);
 
   const discardImage = () => {
     if (fileInputRef.current) fileInputRef.current.value = "";
@@ -172,7 +174,9 @@ const TempThread: FC = () => {
   const isBlocked = !user && !loading;
 
   return (
-    <ThreadLayout>
+    <ThreadLayout
+      onFileDrop={(file) => messageInputRef.current?.handleFile(file)}
+    >
       <MessagesLayout
         messages={isBlocked ? [] : messages}
         isFetchingResponse={isBlocked ? false : isFetchingResponse}
@@ -184,6 +188,7 @@ const TempThread: FC = () => {
         emptyStateText="Temporary Thread"
       />
       <MessageInput
+        ref={messageInputRef}
         input={isBlocked ? "" : input}
         setInput={(val) => setInput("home", val)}
         isListening={isBlocked ? false : isListening}

--- a/src/layouts/Thread/layout.tsx
+++ b/src/layouts/Thread/layout.tsx
@@ -1,10 +1,53 @@
 import { FC, ReactNode, useState, useRef } from "react";
-import { Flex, Text } from "@chakra-ui/react";
+import { Flex, Icon, Text, useColorMode } from "@chakra-ui/react";
+import { IoMdImage } from "react-icons/io";
+import { useTheme } from "@/stores";
 
 interface ThreadLayoutProps {
   children: ReactNode;
   onFileDrop?: (file: File) => void;
 }
+
+const DropOverlay: FC = () => {
+  const { colorMode } = useColorMode();
+  const { colorScheme } = useTheme();
+
+  const borderColor =
+    colorMode === "dark" ? `${colorScheme}.300` : `${colorScheme}.500`;
+
+  return (
+    <Flex
+      position="absolute"
+      inset={0}
+      bg="blackAlpha.600"
+      zIndex={10}
+      align="center"
+      justify="center"
+      pointerEvents="none"
+      borderWidth="1px"
+      borderColor={borderColor}
+    >
+      <Flex
+        direction="column"
+        align="center"
+        pointerEvents="none"
+        gap={4}
+        px={6}
+        py={4}
+      >
+        <Icon as={IoMdImage} boxSize={16} color="white" />
+        <Text
+          fontSize="2xl"
+          color="white"
+          fontWeight="semibold"
+          textAlign="center"
+        >
+          Drop your image here
+        </Text>
+      </Flex>
+    </Flex>
+  );
+};
 
 const ThreadLayout: FC<ThreadLayoutProps> = ({ children, onFileDrop }) => {
   const [isDragging, setIsDragging] = useState(false);
@@ -21,7 +64,8 @@ const ThreadLayout: FC<ThreadLayoutProps> = ({ children, onFileDrop }) => {
     if (!onFileDrop) return;
     e.preventDefault();
     dragCounter.current--;
-    if (dragCounter.current === 0) {
+    if (dragCounter.current <= 0) {
+      dragCounter.current = 0;
       setIsDragging(false);
     }
   };
@@ -54,24 +98,7 @@ const ThreadLayout: FC<ThreadLayoutProps> = ({ children, onFileDrop }) => {
       onDragOver={handleDragOver}
       onDrop={handleDrop}
     >
-      {isDragging && (
-        <Flex
-          position="absolute"
-          top={0}
-          left={0}
-          right={0}
-          bottom={0}
-          bg="blackAlpha.600"
-          zIndex={10}
-          align="center"
-          justify="center"
-          pointerEvents="none"
-        >
-          <Text fontSize="2xl" color="white">
-            Drop your image here
-          </Text>
-        </Flex>
-      )}
+      {isDragging && onFileDrop && <DropOverlay />}
       {children}
     </Flex>
   );

--- a/src/layouts/Thread/layout.tsx
+++ b/src/layouts/Thread/layout.tsx
@@ -1,13 +1,77 @@
-import { FC, ReactNode } from "react";
-import { Flex } from "@chakra-ui/react";
+import { FC, ReactNode, useState, useRef } from "react";
+import { Flex, Text } from "@chakra-ui/react";
 
 interface ThreadLayoutProps {
   children: ReactNode;
+  onFileDrop?: (file: File) => void;
 }
 
-const ThreadLayout: FC<ThreadLayoutProps> = ({ children }) => {
+const ThreadLayout: FC<ThreadLayoutProps> = ({ children, onFileDrop }) => {
+  const [isDragging, setIsDragging] = useState(false);
+  const dragCounter = useRef(0);
+
+  const handleDragEnter = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!onFileDrop) return;
+    e.preventDefault();
+    dragCounter.current++;
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!onFileDrop) return;
+    e.preventDefault();
+    dragCounter.current--;
+    if (dragCounter.current === 0) {
+      setIsDragging(false);
+    }
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!onFileDrop) return;
+    e.preventDefault();
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!onFileDrop) return;
+    e.preventDefault();
+    setIsDragging(false);
+    dragCounter.current = 0;
+    const file = e.dataTransfer.files?.[0];
+    if (file && file.type.startsWith("image/")) {
+      onFileDrop(file);
+    }
+  };
+
   return (
-    <Flex bgColor="background" direction="column" flex="1" h="100%">
+    <Flex
+      bgColor="background"
+      direction="column"
+      flex="1"
+      h="100%"
+      position="relative"
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
+      {isDragging && (
+        <Flex
+          position="absolute"
+          top={0}
+          left={0}
+          right={0}
+          bottom={0}
+          bg="blackAlpha.600"
+          zIndex={10}
+          align="center"
+          justify="center"
+          pointerEvents="none"
+        >
+          <Text fontSize="2xl" color="white">
+            Drop your image here
+          </Text>
+        </Flex>
+      )}
       {children}
     </Flex>
   );


### PR DESCRIPTION
## Summary
- add drag-and-drop overlay to thread layout for dropping images
- expose handleFile in MessageInput to support external drops
- wire pages to forward dropped files into MessageInput

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892b0da158c8327bd7b6b74b574bb9f