### PR TITLE
feat: add settings overlay

### DIFF
--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { FC } from "react";
+import {
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  FormControl,
+  FormLabel,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Switch,
+  useColorMode,
+} from "@chakra-ui/react";
+
+interface SettingsProps {
+  type: "persistent" | "temporary";
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const Settings: FC<SettingsProps> = ({ type, isOpen, onClose }) => {
+  const { colorMode, toggleColorMode } = useColorMode();
+
+  const content = (
+    <FormControl display="flex" alignItems="center">
+      <FormLabel htmlFor="dark-mode" mb="0">
+        Enable dark mode
+      </FormLabel>
+      <Switch
+        id="dark-mode"
+        isChecked={colorMode === "dark"}
+        onChange={toggleColorMode}
+      />
+    </FormControl>
+  );
+
+  return type === "persistent" ? (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Settings</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>{content}</ModalBody>
+      </ModalContent>
+    </Modal>
+  ) : (
+    <Drawer isOpen={isOpen} onClose={onClose} size="full" placement="left">
+      <DrawerOverlay />
+      <DrawerContent>
+        <DrawerHeader>Settings</DrawerHeader>
+        <DrawerBody>{content}</DrawerBody>
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+export default Settings;
+

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -33,6 +33,7 @@ import {
   Text,
   Tooltip,
   useBreakpointValue,
+  useDisclosure,
 } from "@chakra-ui/react";
 import { FiLogOut, FiUserCheck } from "react-icons/fi";
 import { IoAdd, IoSearch, IoSettingsSharp } from "react-icons/io5";
@@ -41,6 +42,7 @@ import { supabase } from "@/lib";
 import { Spinner, Input, MenuList, MenuItem } from "@themed-components";
 import { useAuth, useToastStore } from "@/stores";
 import { ThreadList } from "@/components";
+import Settings from "@/components/Settings";
 
 interface SideBarProps {
   type: "temporary" | "persistent";
@@ -70,12 +72,13 @@ const NewChatButton = () => {
   );
 };
 
-const SettingsButton = () => (
+const SettingsButton = ({ onClick }: { onClick: () => void }) => (
   <Tooltip label="Settings">
     <IconButton
       aria-label="Settings"
       variant="ghost"
       icon={<IoSettingsSharp />}
+      onClick={onClick}
     />
   </Tooltip>
 );
@@ -132,6 +135,12 @@ const SideBar: FC<SideBarProps> = ({ type, isOpen, placement, onClose }) => {
   const { user, setLoading: setAuthLoading, loading: authLoading } = useAuth();
   const router = useRouter();
   const isLargeScreen = useBreakpointValue({ base: false, lg: true });
+
+  const {
+    isOpen: isSettingsOpen,
+    onOpen: onSettingsOpen,
+    onClose: onSettingsClose,
+  } = useDisclosure();
 
   const [threads, setThreads] = useState<Thread[]>([]);
   const [loading, setLoading] = useState(true);
@@ -366,7 +375,7 @@ const SideBar: FC<SideBarProps> = ({ type, isOpen, placement, onClose }) => {
             </Flex>
             <Flex flexShrink={0}>
               <NewChatButton />
-              <SettingsButton />
+              <SettingsButton onClick={onSettingsOpen} />
             </Flex>
           </Flex>
           <Flex p={3}>
@@ -395,74 +404,83 @@ const SideBar: FC<SideBarProps> = ({ type, isOpen, placement, onClose }) => {
 
   if (authLoading || !user) return null;
 
-  return type === "persistent" ? (
+  return (
     <Fragment>
-      {content}
-      <Divider orientation="vertical" />
-    </Fragment>
-  ) : (
-    <Drawer
-      isOpen={!!isOpen}
-      placement={placement!}
-      onClose={onClose!}
-      size="xs"
-    >
-      <DrawerOverlay />
-      <DrawerContent>
-        <Card borderRadius={0} h="100vh">
-          <DrawerHeader
-            px={3}
-            py={2}
-            pb={3}
-            display="flex"
-            justifyContent="space-between"
-          >
-            <Flex align="center" justify="start" gap={3}>
-              <MenuItems
-                user={user}
-                switchAccount={handleGoogleSignIn}
-                signOut={handleSignOut}
-              />
-              <Box
-                lineHeight="1.2"
-                maxW="170px"
-                overflow="hidden"
-                whiteSpace="nowrap"
-                textOverflow="ellipsis"
+      {type === "persistent" ? (
+        <Fragment>
+          {content}
+          <Divider orientation="vertical" />
+        </Fragment>
+      ) : (
+        <Drawer
+          isOpen={!!isOpen}
+          placement={placement!}
+          onClose={onClose!}
+          size="xs"
+        >
+          <DrawerOverlay />
+          <DrawerContent>
+            <Card borderRadius={0} h="100vh">
+              <DrawerHeader
+                px={3}
+                py={2}
+                pb={3}
+                display="flex"
+                justifyContent="space-between"
               >
-                <Text fontWeight="bold" fontSize="sm" isTruncated>
-                  {user?.user_metadata?.name}
-                </Text>
-                <Text fontSize="xs" color="gray.400" isTruncated>
-                  {user?.email}
-                </Text>
-              </Box>
-            </Flex>
-            <Box>
-              <NewChatButton />
-              <SettingsButton />
-            </Box>
-          </DrawerHeader>
-          <Flex px={3} pb={3}>
-            <SearchBar onSearch={handleSearch} />
-          </Flex>
-          <DrawerBody
-            p={0}
-            overflow="hidden"
-            display="flex"
-            borderTopWidth="1px"
-          >
-            {loading ? (
-              <Flex flex="1" justify="center" align="center">
-                <Spinner size="xl" />
+                <Flex align="center" justify="start" gap={3}>
+                  <MenuItems
+                    user={user}
+                    switchAccount={handleGoogleSignIn}
+                    signOut={handleSignOut}
+                  />
+                  <Box
+                    lineHeight="1.2"
+                    maxW="170px"
+                    overflow="hidden"
+                    whiteSpace="nowrap"
+                    textOverflow="ellipsis"
+                  >
+                    <Text fontWeight="bold" fontSize="sm" isTruncated>
+                      {user?.user_metadata?.name}
+                    </Text>
+                    <Text fontSize="xs" color="gray.400" isTruncated>
+                      {user?.email}
+                    </Text>
+                  </Box>
+                </Flex>
+                <Box>
+                  <NewChatButton />
+                  <SettingsButton onClick={onSettingsOpen} />
+                </Box>
+              </DrawerHeader>
+              <Flex px={3} pb={3}>
+                <SearchBar onSearch={handleSearch} />
               </Flex>
-            ) : (
-              <ThreadList threads={threads} searchTerm={searchTerm} />
-            )}
-          </DrawerBody>
-        </Card>
-      </DrawerContent>
-    </Drawer>
+              <DrawerBody
+                p={0}
+                overflow="hidden"
+                display="flex"
+                borderTopWidth="1px"
+              >
+                {loading ? (
+                  <Flex flex="1" justify="center" align="center">
+                    <Spinner size="xl" />
+                  </Flex>
+                ) : (
+                  <ThreadList threads={threads} searchTerm={searchTerm} />
+                )}
+              </DrawerBody>
+            </Card>
+          </DrawerContent>
+        </Drawer>
+      )}
+      <Settings
+        type={type}
+        isOpen={isSettingsOpen}
+        onClose={onSettingsClose}
+      />
+    </Fragment>
   );
 };
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,6 +6,7 @@ import ThreadList from "@/components/ThreadList";
 import ThreadItem from "@/components/ThreadItem";
 import AuthInitializer from "@/components/AuthInitializer";
 import ThreadWrapper from "@/components/ThreadWrapper";
+import Settings from "@/components/Settings";
 
 export {
   NavigationBar,
@@ -16,4 +17,5 @@ export {
   ThreadItem,
   ThreadWrapper,
   AuthInitializer,
+  Settings,
 };


### PR DESCRIPTION
## Summary
- add settings component shown as modal or full drawer
- wire settings button in sidebar

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68945433e8fc83279f533dc5eec40ba9