### PR TITLE
feat: show active gemini model

### DIFF
--- a/src/app/api/gemini/route.ts
+++ b/src/app/api/gemini/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { GEMINI_MODEL } from "@/lib";
 
 export async function OPTIONS() {
   const headers = new Headers();
@@ -36,7 +37,7 @@ export async function POST(req: Request) {
     }
 
     const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${apiKey}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/src/components/NavigationBar/index.tsx
+++ b/src/components/NavigationBar/index.tsx
@@ -22,7 +22,7 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 
-import { supabase } from "@/lib";
+import { supabase, GEMINI_MODEL } from "@/lib";
 import { useAuth } from "@/stores";
 import { Button } from "@themed-components";
 import { useToastStore } from "@/stores";
@@ -151,6 +151,9 @@ const NavigationBar: FC = () => {
               noOfLines={1}
             >
               {pathname === "/" ? "Xeenapz" : currentThreadTitle || "Xeenapz"}
+            </Text>
+            <Text fontSize="xs" color="gray.500" noOfLines={1}>
+              {GEMINI_MODEL}
             </Text>
           </Flex>
 

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -1,0 +1,2 @@
+export const GEMINI_MODEL =
+  process.env.NEXT_PUBLIC_GEMINI_MODEL || "gemini-1.5-flash";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,4 @@
 export { supabase } from "./supabase/client";
 export * from "@/lib/speech/recognition";
 export * from "@/lib/speech/tts";
+export * from "./gemini";


### PR DESCRIPTION
## Summary
- display active Gemini model version in navigation bar
- centralize model name for API and UI

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689734d641d0832791026c504e163823