### PR TITLE
fix: left-align navbar elements for better responsiveness

### DIFF
--- a/src/components/NavigationBar/index.tsx
+++ b/src/components/NavigationBar/index.tsx
@@ -136,53 +136,54 @@ const NavigationBar: FC = () => {
     <Fragment>
       <Card as="nav" width="100%" zIndex="50" borderRadius={0}>
         <Flex py="3" px="6" align="center" justify="space-between" gap={2}>
-          <Flex align="center" gap={3} display={{ base: "block", lg: "none" }}>
-            {user ? (
-              <IconButton
-                aria-label="Toggle Sidebar"
-                icon={<IoMdMenu />}
-                variant="ghost"
-                onClick={onOpen}
-              />
-            ) : (
-              <IconButton
-                aria-label="New Chat"
-                icon={<IoAdd />}
-                variant="ghost"
-              />
-            )}
+          <Flex align="center" gap={3} flex="1" minW={0}>
+            <Flex align="center" display={{ base: "flex", lg: "none" }}>
+              {user ? (
+                <IconButton
+                  aria-label="Toggle Sidebar"
+                  icon={<IoMdMenu />}
+                  variant="ghost"
+                  onClick={onOpen}
+                />
+              ) : (
+                <IconButton
+                  aria-label="New Chat"
+                  icon={<IoAdd />}
+                  variant="ghost"
+                />
+              )}
+            </Flex>
+
+            <Flex align="start" direction="column" flex="1" minW={0}>
+              <Text fontSize="lg" fontWeight="bold" noOfLines={1}>
+                {pathname === "/" ? "Xeenapz" : currentThreadTitle || "Xeenapz"}
+              </Text>
+              <Menu>
+                <MenuButton
+                  as={Button}
+                  size="xs"
+                  variant="ghost"
+                  color="secondaryText"
+                  px={0}
+                  maxW="100%"
+                  overflow="hidden"
+                  textOverflow="ellipsis"
+                  whiteSpace="nowrap"
+                >
+                  {formattedModel}
+                </MenuButton>
+                <MenuList>
+                  {GEMINI_MODELS.map((m) => (
+                    <MenuItem key={m} onClick={() => setModel(m)}>
+                      {formatModel(m)}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </Menu>
+            </Flex>
           </Flex>
 
-          <Flex align="start" direction="column">
-            <Text
-              fontSize="lg"
-              fontWeight="bold"
-              textAlign="center"
-              noOfLines={1}
-            >
-              {pathname === "/" ? "Xeenapz" : currentThreadTitle || "Xeenapz"}
-            </Text>
-            <Menu>
-              <MenuButton
-                as={Button}
-                size="xs"
-                variant="ghost"
-                color="secondaryText"
-                px={0}
-              >
-                {formattedModel}
-              </MenuButton>
-              <MenuList>
-                {GEMINI_MODELS.map((m) => (
-                  <MenuItem key={m} onClick={() => setModel(m)}>
-                    {formatModel(m)}
-                  </MenuItem>
-                ))}
-              </MenuList>
-            </Menu>
-          </Flex>
-
-          <Flex align="center" gap={4}>
+          <Flex align="center" gap={4} flexShrink={0}>
             {user && (pathname === "/" || pathname === "/thread/temp") && (
               <IconButton
                 aria-label="Temporary Chat"


### PR DESCRIPTION
## Summary
- keep menu icon, thread title, and model selector grouped on the left
- truncate model selector text to avoid layout shifts
- prevent right-side controls from overlapping by giving left section flexible space

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897f537238883279fbc7f0b2e8ba102