### PR TITLE
feat: copy message with toast

### DIFF
--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FC, memo } from "react";
+import { FC, memo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { format } from "date-fns";
 import { enUS } from "date-fns/locale";
@@ -15,6 +15,7 @@ import {
   Image,
   Tooltip,
   IconButton,
+  useToast,
   BoxProps,
 } from "@chakra-ui/react";
 import { useTheme } from "@/stores";
@@ -58,6 +59,25 @@ const MessageItem: FC<MessageItemProps> = ({
     });
 
   const { colorScheme } = useTheme();
+  const toast = useToast();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!message.text) return;
+    try {
+      await navigator.clipboard.writeText(message.text);
+      setCopied(true);
+      toast({
+        title: "Message copied",
+        status: "success",
+        duration: 2000,
+        isClosable: true,
+      });
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy message", err);
+    }
+  };
 
   if (!message.text && !message.image) return null;
 
@@ -143,16 +163,17 @@ const MessageItem: FC<MessageItemProps> = ({
                 />
               </Tooltip>
             )}
-            <Tooltip
-              label="Copy Message"
-            >
-              <IconButton
-                aria-label="Copy Message"
-                icon={<BiSolidCopy />}
-                variant="ghost"
-                size="xs"
-              />
-            </Tooltip>
+            {message.text && (
+              <Tooltip label="Copy Message">
+                <IconButton
+                  aria-label="Copy Message"
+                  icon={copied ? <FaCheck /> : <BiSolidCopy />}
+                  variant="ghost"
+                  size="xs"
+                  onClick={handleCopy}
+                />
+              </Tooltip>
+            )}
             </Flex>
           </Flex>
         </Box>


### PR DESCRIPTION
## Summary
- enable copying chat messages with clipboard and success toast
- toggle copy icon between BiSolidCopy and FaCheck to indicate copy status

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: supabaseUrl is required)


------
https://chatgpt.com/codex/tasks/task_e_689805d5a8c08327869c99d09d2b7572