### PR TITLE
feat: enable retrying bot responses

### DIFF
--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -7,7 +7,7 @@ import { enUS } from "date-fns/locale";
 import { HiSpeakerWave } from "react-icons/hi2";
 import { IoStop } from "react-icons/io5";
 import { BiSolidCopy } from "react-icons/bi";
-import { FaCheck } from "react-icons/fa6";
+import { FaCheck, FaArrowsRotate } from "react-icons/fa6";
 import {
   Box,
   Flex,
@@ -41,6 +41,7 @@ interface MessageItemProps extends BoxProps {
   ) => void;
   setPlayingMessage: (msg: string | null) => void;
   playingMessage: string | null;
+  onRetry?: () => void;
 }
 
 const MessageItem: FC<MessageItemProps> = ({
@@ -49,6 +50,7 @@ const MessageItem: FC<MessageItemProps> = ({
   speakText,
   playingMessage,
   setPlayingMessage,
+  onRetry,
   ...props
 }) => {
   const isUser = message.sender === "user";
@@ -143,6 +145,17 @@ const MessageItem: FC<MessageItemProps> = ({
           <Flex align="center" justify="center" gap={1}>
             {user && <Text fontSize="xs" order={isUser ? 2 : 1}>{formattedTime}</Text>}
             <Flex align="center" justify="center" gap={0} order={isUser ? 1 : 2}>
+            {!isUser && message.text && onRetry && (
+              <Tooltip label="Try again">
+                <IconButton
+                  aria-label="Try again"
+                  icon={<FaArrowsRotate />}
+                  variant="ghost"
+                  size="xs"
+                  onClick={onRetry}
+                />
+              </Tooltip>
+            )}
             {!isUser && message.text && (
               <Tooltip
                 label={playingMessage === message.text ? "Stop" : "Read aloud"}

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -145,17 +145,6 @@ const MessageItem: FC<MessageItemProps> = ({
           <Flex align="center" justify="center" gap={1}>
             {user && <Text fontSize="xs" order={isUser ? 2 : 1}>{formattedTime}</Text>}
             <Flex align="center" justify="center" gap={0} order={isUser ? 1 : 2}>
-            {!isUser && message.text && onRetry && (
-              <Tooltip label="Try again">
-                <IconButton
-                  aria-label="Try again"
-                  icon={<FaArrowsRotate />}
-                  variant="ghost"
-                  size="xs"
-                  onClick={onRetry}
-                />
-              </Tooltip>
-            )}
             {!isUser && message.text && (
               <Tooltip
                 label={playingMessage === message.text ? "Stop" : "Read aloud"}
@@ -197,6 +186,17 @@ const MessageItem: FC<MessageItemProps> = ({
                     />
                   </Tooltip>
                 )
+              )}
+              {!isUser && message.text && onRetry && (
+                <Tooltip label="Try again">
+                  <IconButton
+                    aria-label="Try again"
+                    icon={<FaArrowsRotate />}
+                    variant="ghost"
+                    size="xs"
+                    onClick={onRetry}
+                  />
+                </Tooltip>
               )}
             </Flex>
           </Flex>

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -53,6 +53,7 @@ interface MessagesLayoutProps {
   isLoading?: boolean;
   emptyStateText?: string;
   onLoadMore?: () => Promise<void>;
+  onRetryMessage?: (message: Message) => void;
 }
 
 const MessagesLayout: FC<MessagesLayoutProps> = ({
@@ -66,6 +67,7 @@ const MessagesLayout: FC<MessagesLayoutProps> = ({
   isLoading = false,
   emptyStateText = "Hello, what can I help with?",
   onLoadMore,
+  onRetryMessage,
 }) => {
   const { user: authUser } = useAuth();
   const virtuosoRef = useRef<VirtuosoHandle>(null);
@@ -221,6 +223,7 @@ const MessagesLayout: FC<MessagesLayoutProps> = ({
                     speakText={speakText}
                     playingMessage={playingMessage}
                     setPlayingMessage={setPlayingMessage}
+                    onRetry={onRetryMessage ? () => onRetryMessage(msg) : undefined}
                     mt={isFirst && !authUser ? 3 : 0}
                     pt={isFirst ? 3 : 2}
                     pb={isLast ? 3 : 2}


### PR DESCRIPTION
## Summary
- add "try again" button with FaArrowsRotate for bot messages
- allow MessagesLayout to request a new bot response and update message in place
- implement retry logic for home, thread, and temp thread pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689816b3609883279458bec8ae37db26