### PR TITLE
Include images when retrying bot responses

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -221,6 +221,22 @@ const Home: FC = () => {
       }
       return newMsgs;
     });
+    let base64Image: string | null = null;
+    if (userMessage.image?.url) {
+      try {
+        const resImg = await fetch(userMessage.image.url);
+        const blob = await resImg.blob();
+        base64Image = await new Promise((resolve) => {
+          const reader = new FileReader();
+          reader.onloadend = () =>
+            resolve((reader.result as string).split(",")[1]);
+          reader.onerror = () => resolve(null);
+          reader.readAsDataURL(blob);
+        });
+      } catch (e) {
+        console.error("Failed to fetch image for retry:", e);
+      }
+    }
 
     setIsFetchingResponse(true);
     try {
@@ -229,6 +245,7 @@ const Home: FC = () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           message: userMessage.text || null,
+          image: base64Image,
           model,
         }),
       });

--- a/src/app/thread/[threadId]/page.tsx
+++ b/src/app/thread/[threadId]/page.tsx
@@ -255,6 +255,23 @@ const Thread: FC = () => {
     temp[index] = { ...temp[index], text: null };
     setMessages(threadId, temp);
 
+    let base64Image: string | null = null;
+    if (userMessage.image?.url) {
+      try {
+        const resImg = await fetch(userMessage.image.url);
+        const blob = await resImg.blob();
+        base64Image = await new Promise((resolve) => {
+          const reader = new FileReader();
+          reader.onloadend = () =>
+            resolve((reader.result as string).split(",")[1]);
+          reader.onerror = () => resolve(null);
+          reader.readAsDataURL(blob);
+        });
+      } catch (e) {
+        console.error("Failed to fetch image for retry:", e);
+      }
+    }
+
     setIsFetchingResponse(true);
     try {
       const res = await fetch("/api/gemini", {
@@ -262,6 +279,7 @@ const Thread: FC = () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           message: userMessage.text || null,
+          image: base64Image,
           model,
         }),
       });

--- a/src/app/thread/temp/page.tsx
+++ b/src/app/thread/temp/page.tsx
@@ -192,12 +192,33 @@ const TempThread: FC = () => {
       return newMsgs;
     });
 
+    let base64Image: string | null = null;
+    if (userMessage.image?.url) {
+      try {
+        const resImg = await fetch(userMessage.image.url);
+        const blob = await resImg.blob();
+        base64Image = await new Promise((resolve) => {
+          const reader = new FileReader();
+          reader.onloadend = () =>
+            resolve((reader.result as string).split(",")[1]);
+          reader.onerror = () => resolve(null);
+          reader.readAsDataURL(blob);
+        });
+      } catch (e) {
+        console.error("Failed to fetch image for retry:", e);
+      }
+    }
+
     setIsFetchingResponse(true);
     try {
       const res = await fetch("/api/gemini", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: userMessage.text || null, model }),
+        body: JSON.stringify({
+          message: userMessage.text || null,
+          image: base64Image,
+          model,
+        }),
       });
 
       const data = await res.json();


### PR DESCRIPTION
## Summary
- fetch image data when retrying a message and resend with the request
- wire image data through retry flow so Gemini can respond

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898225845e88327a46a6435897ddd55