### PR TITLE
Add responsive settings modal accessible from sidebar

### DIFF
--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { FC } from "react";
+import {
+  Box,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  Stack,
+  Text,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+  useBreakpointValue,
+} from "@chakra-ui/react";
+import { Button } from "@themed-components";
+
+interface SettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const sections = [
+  {
+    title: "General",
+    items: ["Item 1", "Item 2"],
+  },
+  {
+    title: "Appearance",
+    items: ["Item 1", "Item 2"],
+  },
+];
+
+const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
+  const isMobile = useBreakpointValue({ base: true, md: false });
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="xl">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Settings</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          {isMobile ? (
+            <Stack spacing={4}>
+              {sections.map((section) => (
+                <Box key={section.title}>
+                  <Text fontWeight="bold" mb={2}>
+                    {section.title}
+                  </Text>
+                  <Stack spacing={1}>
+                    {section.items.map((item) => (
+                      <Text key={item}>{item}</Text>
+                    ))}
+                  </Stack>
+                </Box>
+              ))}
+            </Stack>
+          ) : (
+            <Tabs orientation="vertical" variant="enclosed">
+              <TabList minW="150px">
+                {sections.map((section) => (
+                  <Tab key={section.title}>{section.title}</Tab>
+                ))}
+              </TabList>
+              <TabPanels>
+                {sections.map((section) => (
+                  <TabPanel key={section.title} p={0}>
+                    <Stack spacing={1} align="start" p={4}>
+                      {section.items.map((item) => (
+                        <Text key={item}>{item}</Text>
+                      ))}
+                    </Stack>
+                  </TabPanel>
+                ))}
+              </TabPanels>
+            </Tabs>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" mr={3} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={onClose}>Save</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default SettingsModal;
+

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -5,7 +5,6 @@ import {
   Box,
   Modal,
   ModalOverlay,
-  ModalContent,
   ModalHeader,
   ModalBody,
   ModalFooter,
@@ -18,8 +17,9 @@ import {
   Tab,
   TabPanel,
   useBreakpointValue,
+  useColorMode,
 } from "@chakra-ui/react";
-import { Button } from "@themed-components";
+import { Button, ModalContent } from "@themed-components";
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -39,9 +39,35 @@ const sections = [
 
 const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
   const isMobile = useBreakpointValue({ base: true, md: false });
+  const { colorMode } = useColorMode();
+
+  const getBg = (
+    state: "base" | "hover" | "active" | "focus",
+    isSelected: boolean
+  ) => {
+    const isDark = colorMode === "dark";
+
+    const palette = {
+      base: isDark ? "gray.800" : "gray.100",
+      hover: isDark ? "gray.700" : "gray.200",
+      active: isDark ? "gray.600" : "gray.300",
+      focus: isDark ? "gray.700" : "gray.100",
+      nonActiveHover: isDark ? "gray.800" : "gray.100",
+      nonActiveActive: isDark ? "gray.700" : "gray.200",
+    } as const;
+
+    if (!isSelected) {
+      if (state === "base") return "transparent";
+      if (state === "hover") return palette.nonActiveHover;
+      if (state === "active") return palette.nonActiveActive;
+      if (state === "focus") return palette.focus;
+    }
+
+    return palette[state];
+  };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} size="xl">
+    <Modal isOpen={isOpen} onClose={onClose} size="xl" isCentered>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>Settings</ModalHeader>
@@ -63,10 +89,26 @@ const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
               ))}
             </Stack>
           ) : (
-            <Tabs orientation="vertical" variant="enclosed">
+            <Tabs orientation="vertical" variant="unstyled">
               <TabList minW="150px">
                 {sections.map((section) => (
-                  <Tab key={section.title}>{section.title}</Tab>
+                  <Tab
+                    key={section.title}
+                    justifyContent="flex-start"
+                    borderRadius="md"
+                    bgColor={getBg("base", false)}
+                    _hover={{ bgColor: getBg("hover", false) }}
+                    _active={{ bgColor: getBg("active", false) }}
+                    _focus={{ bgColor: getBg("focus", false) }}
+                    _selected={{
+                      bgColor: getBg("base", true),
+                      _hover: { bgColor: getBg("hover", true) },
+                      _active: { bgColor: getBg("active", true) },
+                      _focus: { bgColor: getBg("focus", true) },
+                    }}
+                  >
+                    {section.title}
+                  </Tab>
                 ))}
               </TabList>
               <TabPanels>

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FC } from "react";
+import { FC, ReactNode } from "react";
 import {
   Box,
   Modal,
@@ -18,6 +18,8 @@ import {
   TabPanel,
   useBreakpointValue,
   useColorMode,
+  Flex,
+  Switch,
 } from "@chakra-ui/react";
 import { Button, ModalContent } from "@themed-components";
 
@@ -26,20 +28,9 @@ interface SettingsModalProps {
   onClose: () => void;
 }
 
-const sections = [
-  {
-    title: "General",
-    items: ["Item 1", "Item 2"],
-  },
-  {
-    title: "Appearance",
-    items: ["Item 1", "Item 2"],
-  },
-];
-
 const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
   const isMobile = useBreakpointValue({ base: true, md: false });
-  const { colorMode } = useColorMode();
+  const { colorMode, toggleColorMode } = useColorMode();
 
   const getBg = (
     state: "base" | "hover" | "active" | "focus",
@@ -66,6 +57,25 @@ const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
     return palette[state];
   };
 
+  const sections: { title: string; items: ReactNode[] }[] = [
+    {
+      title: "General",
+      items: [
+        <Text key="general-item-1">Item 1</Text>,
+        <Text key="general-item-2">Item 2</Text>,
+      ],
+    },
+    {
+      title: "Appearance",
+      items: [
+        <Flex key="appearance-theme" align="center" justify="space-between" w="full">
+          <Text>Dark mode</Text>
+          <Switch isChecked={colorMode === "dark"} onChange={toggleColorMode} />
+        </Flex>,
+      ],
+    },
+  ];
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="xl" isCentered>
       <ModalOverlay />
@@ -80,11 +90,7 @@ const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
                   <Text fontWeight="bold" mb={2}>
                     {section.title}
                   </Text>
-                  <Stack spacing={1}>
-                    {section.items.map((item) => (
-                      <Text key={item}>{item}</Text>
-                    ))}
-                  </Stack>
+                  <Stack spacing={1}>{section.items.map((item) => item)}</Stack>
                 </Box>
               ))}
             </Stack>
@@ -115,9 +121,7 @@ const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
                 {sections.map((section) => (
                   <TabPanel key={section.title} p={0}>
                     <Stack spacing={1} align="start" p={4}>
-                      {section.items.map((item) => (
-                        <Text key={item}>{item}</Text>
-                      ))}
+                      {section.items.map((item) => item)}
                     </Stack>
                   </TabPanel>
                 ))}

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -33,6 +33,7 @@ import {
   Text,
   Tooltip,
   useBreakpointValue,
+  useDisclosure,
 } from "@chakra-ui/react";
 import { FiLogOut, FiUserCheck } from "react-icons/fi";
 import { IoAdd, IoSearch, IoSettingsSharp } from "react-icons/io5";
@@ -40,7 +41,7 @@ import { IoAdd, IoSearch, IoSettingsSharp } from "react-icons/io5";
 import { supabase } from "@/lib";
 import { Spinner, Input, MenuList, MenuItem } from "@themed-components";
 import { useAuth, useToastStore } from "@/stores";
-import { ThreadList } from "@/components";
+import { ThreadList, SettingsModal } from "@/components";
 
 interface SideBarProps {
   type: "temporary" | "persistent";
@@ -70,12 +71,13 @@ const NewChatButton = () => {
   );
 };
 
-const SettingsButton = () => (
+const SettingsButton = ({ onOpen }: { onOpen: () => void }) => (
   <Tooltip label="Settings">
     <IconButton
       aria-label="Settings"
       variant="ghost"
       icon={<IoSettingsSharp />}
+      onClick={onOpen}
     />
   </Tooltip>
 );
@@ -132,6 +134,11 @@ const SideBar: FC<SideBarProps> = ({ type, isOpen, placement, onClose }) => {
   const { user, setLoading: setAuthLoading, loading: authLoading } = useAuth();
   const router = useRouter();
   const isLargeScreen = useBreakpointValue({ base: false, lg: true });
+  const {
+    isOpen: isSettingsOpen,
+    onOpen: openSettings,
+    onClose: closeSettings,
+  } = useDisclosure();
 
   const [threads, setThreads] = useState<Thread[]>([]);
   const [loading, setLoading] = useState(true);
@@ -366,7 +373,7 @@ const SideBar: FC<SideBarProps> = ({ type, isOpen, placement, onClose }) => {
             </Flex>
             <Flex flexShrink={0}>
               <NewChatButton />
-              <SettingsButton />
+              <SettingsButton onOpen={openSettings} />
             </Flex>
           </Flex>
           <Flex p={3}>
@@ -395,74 +402,74 @@ const SideBar: FC<SideBarProps> = ({ type, isOpen, placement, onClose }) => {
 
   if (authLoading || !user) return null;
 
-  return type === "persistent" ? (
+  return (
     <Fragment>
-      {content}
-      <Divider orientation="vertical" />
-    </Fragment>
-  ) : (
-    <Drawer
-      isOpen={!!isOpen}
-      placement={placement!}
-      onClose={onClose!}
-      size="xs"
-    >
-      <DrawerOverlay />
-      <DrawerContent>
-        <Card borderRadius={0} h="100vh">
-          <DrawerHeader
-            px={3}
-            py={2}
-            pb={3}
-            display="flex"
-            justifyContent="space-between"
-          >
-            <Flex align="center" justify="start" gap={3}>
-              <MenuItems
-                user={user}
-                switchAccount={handleGoogleSignIn}
-                signOut={handleSignOut}
-              />
-              <Box
-                lineHeight="1.2"
-                maxW="170px"
-                overflow="hidden"
-                whiteSpace="nowrap"
-                textOverflow="ellipsis"
+      {type === "persistent" ? (
+        <Fragment>
+          {content}
+          <Divider orientation="vertical" />
+        </Fragment>
+      ) : (
+        <Drawer isOpen={!!isOpen} placement={placement!} onClose={onClose!} size="xs">
+          <DrawerOverlay />
+          <DrawerContent>
+            <Card borderRadius={0} h="100vh">
+              <DrawerHeader
+                px={3}
+                py={2}
+                pb={3}
+                display="flex"
+                justifyContent="space-between"
               >
-                <Text fontWeight="bold" fontSize="sm" isTruncated>
-                  {user?.user_metadata?.name}
-                </Text>
-                <Text fontSize="xs" color="gray.400" isTruncated>
-                  {user?.email}
-                </Text>
-              </Box>
-            </Flex>
-            <Box>
-              <NewChatButton />
-              <SettingsButton />
-            </Box>
-          </DrawerHeader>
-          <Flex px={3} pb={3}>
-            <SearchBar onSearch={handleSearch} />
-          </Flex>
-          <DrawerBody
-            p={0}
-            overflow="hidden"
-            display="flex"
-            borderTopWidth="1px"
-          >
-            {loading ? (
-              <Flex flex="1" justify="center" align="center">
-                <Spinner size="xl" />
+                <Flex align="center" justify="start" gap={3}>
+                  <MenuItems
+                    user={user}
+                    switchAccount={handleGoogleSignIn}
+                    signOut={handleSignOut}
+                  />
+                  <Box
+                    lineHeight="1.2"
+                    maxW="170px"
+                    overflow="hidden"
+                    whiteSpace="nowrap"
+                    textOverflow="ellipsis"
+                  >
+                    <Text fontWeight="bold" fontSize="sm" isTruncated>
+                      {user?.user_metadata?.name}
+                    </Text>
+                    <Text fontSize="xs" color="gray.400" isTruncated>
+                      {user?.email}
+                    </Text>
+                  </Box>
+                </Flex>
+                <Box>
+                  <NewChatButton />
+                  <SettingsButton onOpen={openSettings} />
+                </Box>
+              </DrawerHeader>
+              <Flex px={3} pb={3}>
+                <SearchBar onSearch={handleSearch} />
               </Flex>
-            ) : (
-              <ThreadList threads={threads} searchTerm={searchTerm} />
-            )}
-          </DrawerBody>
-        </Card>
-      </DrawerContent>
-    </Drawer>
+              <DrawerBody
+                p={0}
+                overflow="hidden"
+                display="flex"
+                borderTopWidth="1px"
+              >
+                {loading ? (
+                  <Flex flex="1" justify="center" align="center">
+                    <Spinner size="xl" />
+                  </Flex>
+                ) : (
+                  <ThreadList threads={threads} searchTerm={searchTerm} />
+                )}
+              </DrawerBody>
+            </Card>
+          </DrawerContent>
+        </Drawer>
+      )}
+      <SettingsModal isOpen={isSettingsOpen} onClose={closeSettings} />
+    </Fragment>
   );
 };
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,6 +6,7 @@ import ThreadList from "@/components/ThreadList";
 import ThreadItem from "@/components/ThreadItem";
 import AuthInitializer from "@/components/AuthInitializer";
 import ThreadWrapper from "@/components/ThreadWrapper";
+import SettingsModal from "@/components/Settings";
 
 export {
   NavigationBar,
@@ -16,4 +17,5 @@ export {
   ThreadItem,
   ThreadWrapper,
   AuthInitializer,
+  SettingsModal,
 };

--- a/src/components/ui/ModalContent/index.tsx
+++ b/src/components/ui/ModalContent/index.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { forwardRef } from "react";
+import {
+  ModalContent as ChakraModalContent,
+  useColorMode,
+  type BoxProps,
+} from "@chakra-ui/react";
+
+const ModalContent = forwardRef<HTMLDivElement, BoxProps>((props, ref) => {
+  const { colorMode } = useColorMode();
+
+  return (
+    <ChakraModalContent
+      ref={ref}
+      bgColor={colorMode === "light" ? "surface" : "mutedSurface"}
+      {...props}
+    />
+  );
+});
+
+ModalContent.displayName = "ModalContent";
+
+export default ModalContent;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -6,6 +6,7 @@ import Toast from "./Toast";
 import AlertDialogContent from "./AlertDialogContent";
 import MenuItem from "./MenuItem";
 import MenuList from "./MenuList";
+import ModalContent from "./ModalContent";
 
 export {
   Button,
@@ -16,4 +17,5 @@ export {
   AlertDialogContent,
   MenuItem,
   MenuList,
+  ModalContent,
 };


### PR DESCRIPTION
## Summary
- add SettingsModal component with responsive layout and actions
- integrate settings icon in sidebar to open the modal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b38e1a400832783865ca4a8234cf6