### PR TITLE
feat: add settings modal

### DIFF
--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -22,11 +22,17 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+    <Modal
+      size="xl"
+      scrollBehavior="inside"
+      isOpen={isOpen}
+      onClose={onClose}
+      isCentered
+    >
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>Settings</ModalHeader>
-        <ModalBody>{/* Settings content goes here */}</ModalBody>
+        <ModalBody></ModalBody>
         <ModalFooter>
           <HStack gap={2}>
             <Button variant="ghost" colorScheme="gray" onClick={onClose}>

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { FC } from "react";
+import {
+  Modal,
+  ModalOverlay,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  HStack,
+} from "@chakra-ui/react";
+import { Button, ModalContent } from "@themed-components";
+
+interface SettingsProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
+  const handleSave = () => {
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Settings</ModalHeader>
+        <ModalBody>{/* Settings content goes here */}</ModalBody>
+        <ModalFooter>
+          <HStack gap={2}>
+            <Button variant="ghost" colorScheme="gray" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button variant="ghost" onClick={handleSave}>
+              Save
+            </Button>
+          </HStack>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default Settings;

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -33,6 +33,7 @@ import {
   Text,
   Tooltip,
   useBreakpointValue,
+  useDisclosure,
 } from "@chakra-ui/react";
 import { FiLogOut, FiUserCheck } from "react-icons/fi";
 import { IoAdd, IoSearch, IoSettingsSharp } from "react-icons/io5";
@@ -40,7 +41,7 @@ import { IoAdd, IoSearch, IoSettingsSharp } from "react-icons/io5";
 import { supabase } from "@/lib";
 import { Spinner, Input, MenuList, MenuItem } from "@themed-components";
 import { useAuth, useToastStore } from "@/stores";
-import { ThreadList } from "@/components";
+import { ThreadList, Settings } from "@/components";
 
 interface SideBarProps {
   type: "temporary" | "persistent";
@@ -70,12 +71,13 @@ const NewChatButton = () => {
   );
 };
 
-const SettingsButton = () => (
+const SettingsButton = ({ onClick }: { onClick: () => void }) => (
   <Tooltip label="Settings">
     <IconButton
       aria-label="Settings"
       variant="ghost"
       icon={<IoSettingsSharp />}
+      onClick={onClick}
     />
   </Tooltip>
 );
@@ -141,6 +143,12 @@ const SideBar: FC<SideBarProps> = ({ type, isOpen, placement, onClose }) => {
   const [isResizing, setIsResizing] = useState(false);
 
   const { showToast } = useToastStore();
+
+  const {
+    isOpen: isSettingsOpen,
+    onOpen: onSettingsOpen,
+    onClose: onSettingsClose,
+  } = useDisclosure();
 
   const hasFetchedRef = useRef(false);
 
@@ -366,7 +374,7 @@ const SideBar: FC<SideBarProps> = ({ type, isOpen, placement, onClose }) => {
             </Flex>
             <Flex flexShrink={0}>
               <NewChatButton />
-              <SettingsButton />
+              <SettingsButton onClick={onSettingsOpen} />
             </Flex>
           </Flex>
           <Flex p={3}>
@@ -395,74 +403,79 @@ const SideBar: FC<SideBarProps> = ({ type, isOpen, placement, onClose }) => {
 
   if (authLoading || !user) return null;
 
-  return type === "persistent" ? (
-    <Fragment>
-      {content}
-      <Divider orientation="vertical" />
-    </Fragment>
-  ) : (
-    <Drawer
-      isOpen={!!isOpen}
-      placement={placement!}
-      onClose={onClose!}
-      size="xs"
-    >
-      <DrawerOverlay />
-      <DrawerContent>
-        <Card borderRadius={0} h="100vh">
-          <DrawerHeader
-            px={3}
-            py={2}
-            pb={3}
-            display="flex"
-            justifyContent="space-between"
-          >
-            <Flex align="center" justify="start" gap={3}>
-              <MenuItems
-                user={user}
-                switchAccount={handleGoogleSignIn}
-                signOut={handleSignOut}
-              />
-              <Box
-                lineHeight="1.2"
-                maxW="170px"
-                overflow="hidden"
-                whiteSpace="nowrap"
-                textOverflow="ellipsis"
+  return (
+    <>
+      {type === "persistent" ? (
+        <Fragment>
+          {content}
+          <Divider orientation="vertical" />
+        </Fragment>
+      ) : (
+        <Drawer
+          isOpen={!!isOpen}
+          placement={placement!}
+          onClose={onClose!}
+          size="xs"
+        >
+          <DrawerOverlay />
+          <DrawerContent>
+            <Card borderRadius={0} h="100vh">
+              <DrawerHeader
+                px={3}
+                py={2}
+                pb={3}
+                display="flex"
+                justifyContent="space-between"
               >
-                <Text fontWeight="bold" fontSize="sm" isTruncated>
-                  {user?.user_metadata?.name}
-                </Text>
-                <Text fontSize="xs" color="gray.400" isTruncated>
-                  {user?.email}
-                </Text>
-              </Box>
-            </Flex>
-            <Box>
-              <NewChatButton />
-              <SettingsButton />
-            </Box>
-          </DrawerHeader>
-          <Flex px={3} pb={3}>
-            <SearchBar onSearch={handleSearch} />
-          </Flex>
-          <DrawerBody
-            p={0}
-            overflow="hidden"
-            display="flex"
-            borderTopWidth="1px"
-          >
-            {loading ? (
-              <Flex flex="1" justify="center" align="center">
-                <Spinner size="xl" />
+                <Flex align="center" justify="start" gap={3}>
+                  <MenuItems
+                    user={user}
+                    switchAccount={handleGoogleSignIn}
+                    signOut={handleSignOut}
+                  />
+                  <Box
+                    lineHeight="1.2"
+                    maxW="170px"
+                    overflow="hidden"
+                    whiteSpace="nowrap"
+                    textOverflow="ellipsis"
+                  >
+                    <Text fontWeight="bold" fontSize="sm" isTruncated>
+                      {user?.user_metadata?.name}
+                    </Text>
+                    <Text fontSize="xs" color="gray.400" isTruncated>
+                      {user?.email}
+                    </Text>
+                  </Box>
+                </Flex>
+                <Box>
+                  <NewChatButton />
+                  <SettingsButton onClick={onSettingsOpen} />
+                </Box>
+              </DrawerHeader>
+              <Flex px={3} pb={3}>
+                <SearchBar onSearch={handleSearch} />
               </Flex>
-            ) : (
-              <ThreadList threads={threads} searchTerm={searchTerm} />
-            )}
-          </DrawerBody>
-        </Card>
-      </DrawerContent>
-    </Drawer>
+              <DrawerBody
+                p={0}
+                overflow="hidden"
+                display="flex"
+                borderTopWidth="1px"
+              >
+                {loading ? (
+                  <Flex flex="1" justify="center" align="center">
+                    <Spinner size="xl" />
+                  </Flex>
+                ) : (
+                  <ThreadList threads={threads} searchTerm={searchTerm} />
+                )}
+              </DrawerBody>
+            </Card>
+          </DrawerContent>
+        </Drawer>
+      )}
+      <Settings isOpen={isSettingsOpen} onClose={onSettingsClose} />
+    </>
   );
 };
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,6 +6,7 @@ import ThreadList from "@/components/ThreadList";
 import ThreadItem from "@/components/ThreadItem";
 import AuthInitializer from "@/components/AuthInitializer";
 import ThreadWrapper from "@/components/ThreadWrapper";
+import Settings from "@/components/Settings";
 
 export {
   NavigationBar,
@@ -16,4 +17,5 @@ export {
   ThreadItem,
   ThreadWrapper,
   AuthInitializer,
+  Settings,
 };

--- a/src/components/ui/ModalContent/index.tsx
+++ b/src/components/ui/ModalContent/index.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { forwardRef } from "react";
+import {
+  ModalContent as ChakraModalContent,
+  useColorMode,
+  type BoxProps,
+} from "@chakra-ui/react";
+
+const ModalContent = forwardRef<HTMLDivElement, BoxProps>((props, ref) => {
+  const { colorMode } = useColorMode();
+
+  return (
+    <ChakraModalContent
+      ref={ref}
+      bgColor={colorMode === "light" ? "surface" : "mutedSurface"}
+      {...props}
+    />
+  );
+});
+
+ModalContent.displayName = "ModalContent";
+
+export default ModalContent;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -4,6 +4,7 @@ import Progress from "./Progress";
 import Spinner from "./Spinner";
 import Toast from "./Toast";
 import AlertDialogContent from "./AlertDialogContent";
+import ModalContent from "./ModalContent";
 import MenuItem from "./MenuItem";
 import MenuList from "./MenuList";
 
@@ -14,6 +15,7 @@ export {
   Spinner,
   Toast,
   AlertDialogContent,
+  ModalContent,
   MenuItem,
   MenuList,
 };


### PR DESCRIPTION
## Summary
- add settings modal triggered from sidebar
- introduce reusable ModalContent component with theme-aware background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c2fadccd4832782731228f6f57a02