### PR TITLE
feat: add dark mode toggle to settings

### DIFF
--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FC } from "react";
+import { FC, useState } from "react";
 import {
   Modal,
   ModalOverlay,
@@ -17,9 +17,12 @@ import {
   Flex,
   useBreakpointValue,
   ModalCloseButton,
+  FormControl,
+  FormLabel,
+  Switch,
 } from "@chakra-ui/react";
 import { IoSettingsOutline } from "react-icons/io5";
-import { IoIosColorPalette } from "react-icons/io";
+import { MdOutlineColorLens, MdColorLens } from "react-icons/md";
 import { ModalContent } from "@themed-components";
 import { useTheme } from "@/stores";
 
@@ -29,8 +32,9 @@ interface SettingsProps {
 }
 
 const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
-  const { colorMode } = useColorMode();
+  const { colorMode, toggleColorMode } = useColorMode();
   const { colorScheme } = useTheme();
+  const [tabIndex, setTabIndex] = useState(0);
 
   const getBg = (state: "base" | "hover" | "active" | "selected") => {
     const isDark = colorMode === "dark";
@@ -45,7 +49,12 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
 
   const tabs = [
     { key: "general", label: "General", icon: IoSettingsOutline },
-    { key: "appearance", label: "Appearance", icon: IoIosColorPalette },
+    {
+      key: "appearance",
+      label: "Appearance",
+      icon: MdOutlineColorLens,
+      selectedIcon: MdColorLens,
+    },
     { key: "chat", label: "Chat", icon: IoSettingsOutline },
     { key: "privacy", label: "Data & Privacy", icon: IoSettingsOutline },
     { key: "account", label: "Account", icon: IoSettingsOutline },
@@ -75,6 +84,8 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
             })}
             h="60vh"
             variant="unstyled"
+            index={tabIndex}
+            onChange={setTabIndex}
           >
             <TabList
               w={{ base: "full", md: "200px" }}
@@ -91,7 +102,7 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
               overflowX="hidden"
               flexShrink={0}
             >
-              {tabs.map((t) => (
+              {tabs.map((t, i) => (
                 <Tab
                   key={t.key}
                   justifyContent="flex-start"
@@ -112,7 +123,10 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
                   flex={{ base: "0 1 auto", md: "initial" }}
                 >
                   <Flex align="center" gap={2}>
-                    <Icon as={t.icon} boxSize={4} />
+                    <Icon
+                      as={tabIndex === i ? t.selectedIcon ?? t.icon : t.icon}
+                      boxSize={4}
+                    />
                     {t.label}
                   </Flex>
                 </Tab>
@@ -127,7 +141,18 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
 
             <TabPanels flex="1" minH={0}>
               <TabPanel>General settings go here.</TabPanel>
-              <TabPanel>Appearance settings go here.</TabPanel>
+              <TabPanel>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel htmlFor="color-mode-toggle" mb="0">
+                    Dark Mode
+                  </FormLabel>
+                  <Switch
+                    id="color-mode-toggle"
+                    isChecked={colorMode === "dark"}
+                    onChange={toggleColorMode}
+                  />
+                </FormControl>
+              </TabPanel>
               <TabPanel>Chat preferences go here.</TabPanel>
               <TabPanel>Data & Privacy settings go here.</TabPanel>
               <TabPanel>Account settings go here.</TabPanel>


### PR DESCRIPTION
## Summary
- add appearance tab dark mode toggle
- switch appearance tab icons based on selection state

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689de306cafc8327abae648a56860d41