### PR TITLE
Enable modal preview for message images

### DIFF
--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -14,11 +14,15 @@ import {
   Divider,
   Box,
   Image,
+  Modal,
+  ModalOverlay,
+  ModalCloseButton,
+  ModalBody,
 } from "@chakra-ui/react";
 import { IoStop } from "react-icons/io5";
 import { IoIosMic, IoMdImage, IoMdSend, IoMdClose } from "react-icons/io";
 import { SpeechRecognize } from "@/lib";
-import { Input } from "@themed-components";
+import { Input, ModalContent } from "@themed-components";
 
 export interface MessageInputHandle {
   handleFile: (file: File) => void;
@@ -56,6 +60,7 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
   };
 
   const [preview, setPreview] = useState<string | null>(null);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
 
   const handleFile = (file: File) => {
     if (preview) {
@@ -80,6 +85,7 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     if (preview) URL.revokeObjectURL(preview);
     setPreview(null);
     discardImage();
+    setIsPreviewOpen(false);
   };
 
   useEffect(() => {
@@ -97,6 +103,7 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     if (preview) {
       URL.revokeObjectURL(preview);
       setPreview(null);
+      setIsPreviewOpen(false);
     }
     await sendPromise;
   };
@@ -106,25 +113,53 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       <Divider orientation="horizontal" />
       <Card p={3} borderRadius={0} variant="surface">
         {preview && (
-          <Box position="relative" maxW="100px" mb={3}>
-            <Image src={preview} alt="Preview" borderRadius="md" />
-            <IconButton
-              aria-label="Discard image"
-              size="xs"
-              bg="Background"
-              color="primaryText"
-              _hover={{ bg: "Background", color: "primaryText" }}
-              _active={{ bg: "Background", color: "primaryText" }}
-              _focus={{ bg: "Background", color: "primaryText" }}
-              icon={<IoMdClose />}
-              variant="solid"
-              position="absolute"
-              top={1}
-              right={1}
-              isRound={true}
-              onClick={handleDiscard}
-            />
-          </Box>
+          <>
+            <Box position="relative" maxW="100px" mb={3}>
+              <Image
+                src={preview}
+                alt="Preview"
+                borderRadius="md"
+                cursor="pointer"
+                onClick={() => setIsPreviewOpen(true)}
+              />
+              <IconButton
+                aria-label="Discard image"
+                size="xs"
+                bg="Background"
+                color="primaryText"
+                _hover={{ bg: "Background", color: "primaryText" }}
+                _active={{ bg: "Background", color: "primaryText" }}
+                _focus={{ bg: "Background", color: "primaryText" }}
+                icon={<IoMdClose />}
+                variant="solid"
+                position="absolute"
+                top={1}
+                right={1}
+                isRound={true}
+                onClick={handleDiscard}
+              />
+            </Box>
+            <Modal
+              isOpen={isPreviewOpen}
+              onClose={() => setIsPreviewOpen(false)}
+              isCentered
+              size="xl"
+            >
+              <ModalOverlay />
+              <ModalContent>
+                <ModalCloseButton />
+                <ModalBody p={0}>
+                  <Image
+                    src={preview}
+                    alt="Preview"
+                    w="100%"
+                    maxH="80vh"
+                    objectFit="contain"
+                  />
+                </ModalBody>
+              </ModalContent>
+            </Modal>
+          </>
         )}
         <input
           type="file"

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -55,169 +55,178 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     },
     ref
   ) => {
-  const toggleSpeechRecognition = () => {
-    SpeechRecognize(isListening, resetTranscript);
-  };
+    const toggleSpeechRecognition = () => {
+      SpeechRecognize(isListening, resetTranscript);
+    };
 
-  const [preview, setPreview] = useState<string | null>(null);
-  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+    const [preview, setPreview] = useState<string | null>(null);
+    const [isPreviewOpen, setIsPreviewOpen] = useState(false);
 
-  const handleFile = (file: File) => {
-    if (preview) {
-      URL.revokeObjectURL(preview);
-    }
-    const dt = new DataTransfer();
-    dt.items.add(file);
-    if (fileInputRef.current) {
-      fileInputRef.current.files = dt.files;
-    }
-    const url = URL.createObjectURL(file);
-    setPreview(url);
-  };
-
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    handleFile(file);
-  };
-
-  const handleDiscard = () => {
-    if (preview) URL.revokeObjectURL(preview);
-    setPreview(null);
-    discardImage();
-    setIsPreviewOpen(false);
-  };
-
-  useEffect(() => {
-    return () => {
+    const handleFile = (file: File) => {
       if (preview) {
         URL.revokeObjectURL(preview);
       }
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      if (fileInputRef.current) {
+        fileInputRef.current.files = dt.files;
+      }
+      const url = URL.createObjectURL(file);
+      setPreview(url);
     };
-  }, [preview]);
 
-  useImperativeHandle(ref, () => ({ handleFile }));
+    const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      handleFile(file);
+    };
 
-  const handleSend = async () => {
-    const sendPromise = sendMessage();
-    if (preview) {
-      URL.revokeObjectURL(preview);
+    const handleDiscard = () => {
+      if (preview) URL.revokeObjectURL(preview);
       setPreview(null);
+      discardImage();
       setIsPreviewOpen(false);
-    }
-    await sendPromise;
-  };
+    };
 
-  return (
-    <Fragment>
-      <Divider orientation="horizontal" />
-      <Card p={3} borderRadius={0} variant="surface">
-        {preview && (
-          <>
-            <Box position="relative" maxW="100px" mb={3}>
-              <Image
-                src={preview}
-                alt="Preview"
-                borderRadius="md"
-                cursor="pointer"
-                onClick={() => setIsPreviewOpen(true)}
-              />
-              <IconButton
-                aria-label="Discard image"
-                size="xs"
-                bg="Background"
-                color="primaryText"
-                _hover={{ bg: "Background", color: "primaryText" }}
-                _active={{ bg: "Background", color: "primaryText" }}
-                _focus={{ bg: "Background", color: "primaryText" }}
-                icon={<IoMdClose />}
-                variant="solid"
-                position="absolute"
-                top={1}
-                right={1}
-                isRound={true}
-                onClick={handleDiscard}
-              />
-            </Box>
-            <Modal
-              isOpen={isPreviewOpen}
-              onClose={() => setIsPreviewOpen(false)}
-              isCentered
-              size="xl"
-              motionPreset="none"
-            >
-              <ModalOverlay />
-              <ModalContent>
-                <ModalCloseButton position="fixed" top={4} right={4} />
-                <ModalBody p={0}>
-                  <Image
-                    src={preview}
-                    alt="Preview"
-                    w="100%"
-                    maxH="80vh"
-                    objectFit="contain"
-                  />
-                </ModalBody>
-              </ModalContent>
-            </Modal>
-          </>
-        )}
-        <input
-          type="file"
-          accept="image/*"
-          ref={fileInputRef}
-          style={{ display: "none" }}
-          onChange={handleImageChange}
-        />
-        <Flex gap={2} justify="center" align="center">
-          <Input
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={async (e) => {
-              if (e.key === "Enter" && !e.shiftKey) {
-                e.preventDefault();
-                await handleSend();
-              }
-            }}
-            placeholder="Write a message..."
-            flex="1"
-            variant="filled"
-            isDisabled={isDisabled}
+    useEffect(() => {
+      return () => {
+        if (preview) {
+          URL.revokeObjectURL(preview);
+        }
+      };
+    }, [preview]);
+
+    useImperativeHandle(ref, () => ({ handleFile }));
+
+    const handleSend = async () => {
+      const sendPromise = sendMessage();
+      if (preview) {
+        URL.revokeObjectURL(preview);
+        setPreview(null);
+        setIsPreviewOpen(false);
+      }
+      await sendPromise;
+    };
+
+    return (
+      <Fragment>
+        <Divider orientation="horizontal" />
+        <Card p={3} borderRadius={0} variant="surface">
+          {preview && (
+            <>
+              <Box position="relative" maxW="100px" mb={3}>
+                <Image
+                  src={preview}
+                  alt="Preview"
+                  borderRadius="md"
+                  cursor="pointer"
+                  onClick={() => setIsPreviewOpen(true)}
+                />
+                <IconButton
+                  aria-label="Discard image"
+                  size="xs"
+                  bg="primaryText"
+                  color="background"
+                  _hover={{ bg: "primaryText", color: "background" }}
+                  _active={{ bg: "primaryText", color: "background" }}
+                  _focus={{ bg: "primaryText", color: "background" }}
+                  icon={<IoMdClose />}
+                  variant="solid"
+                  position="absolute"
+                  top={1}
+                  right={1}
+                  isRound={true}
+                  onClick={handleDiscard}
+                />
+              </Box>
+              <Modal
+                isOpen={isPreviewOpen}
+                onClose={() => setIsPreviewOpen(false)}
+                isCentered
+                size="xl"
+                motionPreset="none"
+              >
+                <ModalOverlay />
+                <ModalContent>
+                  <ModalCloseButton
+                    position="fixed"
+                    top={4}
+                    right={4}
+                    borderRadius="full"
+                    bg="primaryText"
+                    color="background"
+                    _hover={{ bg: "primaryText", color: "background" }}
+                    _active={{ bg: "primaryText", color: "background" }}
+                    _focus={{ bg: "primaryText", color: "background" }} />
+                  <ModalBody p={0}>
+                    <Image
+                      src={preview}
+                      alt="Preview"
+                      w="100%"
+                      maxH="80vh"
+                      objectFit="contain"
+                    />
+                  </ModalBody>
+                </ModalContent>
+              </Modal>
+            </>
+          )}
+          <input
+            type="file"
+            accept="image/*"
+            ref={fileInputRef}
+            style={{ display: "none" }}
+            onChange={handleImageChange}
           />
-          <Tooltip label="Upload image">
-            <IconButton
-              aria-label="Upload image"
-              variant="ghost"
-              icon={<IoMdImage />}
-              onClick={() => fileInputRef.current?.click()}
+          <Flex gap={2} justify="center" align="center">
+            <Input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={async (e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  await handleSend();
+                }
+              }}
+              placeholder="Write a message..."
+              flex="1"
+              variant="filled"
               isDisabled={isDisabled}
             />
-          </Tooltip>
-          <Tooltip label={isListening ? "Stop" : "Type by voice"}>
-            <IconButton
-              aria-label="Speech Recognition"
-              variant="ghost"
-              icon={isListening ? <IoStop /> : <IoIosMic />}
-              onClick={toggleSpeechRecognition}
-              isDisabled={isDisabled}
-            />
-          </Tooltip>
-          <Tooltip label="Send message">
-            <IconButton
-              aria-label="Send Message"
-              variant="ghost"
-              icon={<IoMdSend />}
-              isDisabled={
-                isFetchingResponse || (!input.trim() && !preview) || isListening
-              }
-              onClick={handleSend}
-            />
-          </Tooltip>
-        </Flex>
-      </Card>
-    </Fragment>
-  );
-});
+            <Tooltip label="Upload image">
+              <IconButton
+                aria-label="Upload image"
+                variant="ghost"
+                icon={<IoMdImage />}
+                onClick={() => fileInputRef.current?.click()}
+                isDisabled={isDisabled}
+              />
+            </Tooltip>
+            <Tooltip label={isListening ? "Stop" : "Type by voice"}>
+              <IconButton
+                aria-label="Speech Recognition"
+                variant="ghost"
+                icon={isListening ? <IoStop /> : <IoIosMic />}
+                onClick={toggleSpeechRecognition}
+                isDisabled={isDisabled}
+              />
+            </Tooltip>
+            <Tooltip label="Send message">
+              <IconButton
+                aria-label="Send Message"
+                variant="ghost"
+                icon={<IoMdSend />}
+                isDisabled={
+                  isFetchingResponse || (!input.trim() && !preview) || isListening
+                }
+                onClick={handleSend}
+              />
+            </Tooltip>
+          </Flex>
+        </Card>
+      </Fragment>
+    );
+  });
 
 MessageInput.displayName = "MessageInput";
 

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -144,6 +144,7 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
               onClose={() => setIsPreviewOpen(false)}
               isCentered
               size="xl"
+              motionPreset="none"
             >
               <ModalOverlay />
               <ModalContent>

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -147,7 +147,7 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
             >
               <ModalOverlay />
               <ModalContent>
-                <ModalCloseButton />
+                <ModalCloseButton position="fixed" top={4} right={4} />
                 <ModalBody p={0}>
                   <Image
                     src={preview}

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -127,7 +127,17 @@ const MessageItem: FC<MessageItemProps> = ({
               >
                 <ModalOverlay />
                 <ModalContent>
-                  <ModalCloseButton position="fixed" top={4} right={4} />
+                  <ModalCloseButton
+                    position="fixed"
+                    top={4}
+                    right={4}
+                    borderRadius="full"
+                    bg="primaryText"
+                    color="background"
+                    _hover={{ bg: "primaryText", color: "background" }}
+                    _active={{ bg: "primaryText", color: "background" }}
+                    _focus={{ bg: "primaryText", color: "background" }}
+                  />
                   <ModalBody p={0}>
                     <Image
                       src={message.image.url}
@@ -176,27 +186,27 @@ const MessageItem: FC<MessageItemProps> = ({
           <Flex align="center" justify="center" gap={1}>
             {user && <Text fontSize="xs" order={isUser ? 2 : 1}>{formattedTime}</Text>}
             <Flex align="center" justify="center" gap={0} order={isUser ? 1 : 2}>
-            {!isUser && message.text && (
-              <Tooltip
-                label={playingMessage === message.text ? "Stop" : "Read aloud"}
-              >
-                <IconButton
-                  aria-label="Read aloud"
-                  icon={
-                    playingMessage === message.text ? (
-                      <IoStop />
-                    ) : (
-                      <HiSpeakerWave />
-                    )
-                  }
-                  variant="ghost"
-                  size="xs"
-                  onClick={() =>
-                    speakText(message.text!, playingMessage, setPlayingMessage)
-                  }
-                />
-              </Tooltip>
-            )}
+              {!isUser && message.text && (
+                <Tooltip
+                  label={playingMessage === message.text ? "Stop" : "Read aloud"}
+                >
+                  <IconButton
+                    aria-label="Read aloud"
+                    icon={
+                      playingMessage === message.text ? (
+                        <IoStop />
+                      ) : (
+                        <HiSpeakerWave />
+                      )
+                    }
+                    variant="ghost"
+                    size="xs"
+                    onClick={() =>
+                      speakText(message.text!, playingMessage, setPlayingMessage)
+                    }
+                  />
+                </Tooltip>
+              )}
               {message.text && (
                 copied ? (
                   <IconButton

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -123,6 +123,7 @@ const MessageItem: FC<MessageItemProps> = ({
                 onClose={() => setIsImageOpen(false)}
                 isCentered
                 size="xl"
+                motionPreset="none"
               >
                 <ModalOverlay />
                 <ModalContent>

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -126,7 +126,7 @@ const MessageItem: FC<MessageItemProps> = ({
               >
                 <ModalOverlay />
                 <ModalContent>
-                  <ModalCloseButton />
+                  <ModalCloseButton position="fixed" top={4} right={4} />
                   <ModalBody p={0}>
                     <Image
                       src={message.image.url}

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -17,7 +17,12 @@ import {
   IconButton,
   BoxProps,
   useColorMode,
+  Modal,
+  ModalOverlay,
+  ModalCloseButton,
+  ModalBody,
 } from "@chakra-ui/react";
+import { ModalContent } from "@themed-components";
 import { useTheme, useToastStore } from "@/stores";
 
 interface Message {
@@ -64,6 +69,7 @@ const MessageItem: FC<MessageItemProps> = ({
   const { colorMode } = useColorMode();
   const { showToast } = useToastStore();
   const [copied, setCopied] = useState(false);
+  const [isImageOpen, setIsImageOpen] = useState(false);
 
   const handleCopy = async () => {
     if (!message.text) return;
@@ -101,14 +107,38 @@ const MessageItem: FC<MessageItemProps> = ({
           gap={1}
         >
           {message.image && (
-            <Image
-              src={message.image.url}
-              id={message.image.id}
-              alt={message.image.id}
-              mt={2}
-              maxW={200}
-              rounded="md"
-            />
+            <>
+              <Image
+                src={message.image.url}
+                id={message.image.id}
+                alt={message.image.id}
+                mt={2}
+                maxW={200}
+                rounded="md"
+                cursor="pointer"
+                onClick={() => setIsImageOpen(true)}
+              />
+              <Modal
+                isOpen={isImageOpen}
+                onClose={() => setIsImageOpen(false)}
+                isCentered
+                size="xl"
+              >
+                <ModalOverlay />
+                <ModalContent>
+                  <ModalCloseButton />
+                  <ModalBody p={0}>
+                    <Image
+                      src={message.image.url}
+                      alt={message.image.id}
+                      w="100%"
+                      maxH="80vh"
+                      objectFit="contain"
+                    />
+                  </ModalBody>
+                </ModalContent>
+              </Modal>
+            </>
           )}
           {message.text && (
             <Box


### PR DESCRIPTION
## Summary
- make images in chat messages open in a modal when clicked
- allow upload preview images to expand to a modal dialog

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689edeeeae5083279b7e40767e4118e4