### PR TITLE
refactor image preview modal into reusable component

### DIFF
--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -7,22 +7,18 @@ import {
   useImperativeHandle,
 } from "react";
 import {
-  Flex,
-  IconButton,
-  Card,
-  Tooltip,
-  Divider,
-  Box,
-  Image,
-  Modal,
-  ModalOverlay,
-  ModalCloseButton,
-  ModalBody,
-} from "@chakra-ui/react";
+    Flex,
+    IconButton,
+    Card,
+    Tooltip,
+    Divider,
+    Box,
+    Image,
+  } from "@chakra-ui/react";
 import { IoStop } from "react-icons/io5";
 import { IoIosMic, IoMdImage, IoMdSend, IoMdClose } from "react-icons/io";
 import { SpeechRecognize } from "@/lib";
-import { Input, ModalContent } from "@themed-components";
+  import { Input, ImageModal } from "@themed-components";
 
 export interface MessageInputHandle {
   handleFile: (file: File) => void;
@@ -112,65 +108,43 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       <Fragment>
         <Divider orientation="horizontal" />
         <Card p={3} borderRadius={0} variant="surface">
-          {preview && (
-            <>
-              <Box position="relative" maxW="100px" mb={3}>
-                <Image
-                  src={preview}
-                  alt="Preview"
-                  borderRadius="md"
-                  cursor="pointer"
-                  onClick={() => setIsPreviewOpen(true)}
-                />
-                <IconButton
-                  aria-label="Discard image"
-                  size="xs"
-                  bg="primaryText"
-                  color="background"
-                  _hover={{ bg: "primaryText", color: "background" }}
-                  _active={{ bg: "primaryText", color: "background" }}
-                  _focus={{ bg: "primaryText", color: "background" }}
-                  icon={<IoMdClose />}
-                  variant="solid"
-                  position="absolute"
-                  top={1}
-                  right={1}
-                  isRound={true}
-                  onClick={handleDiscard}
-                />
-              </Box>
-              <Modal
-                isOpen={isPreviewOpen}
-                onClose={() => setIsPreviewOpen(false)}
-                isCentered
-                size="xl"
-                motionPreset="none"
-              >
-                <ModalOverlay />
-                <ModalContent>
-                  <ModalCloseButton
-                    position="fixed"
-                    top={4}
-                    right={4}
-                    borderRadius="full"
+            {preview && (
+              <>
+                <Box position="relative" boxSize="100px" mb={3}>
+                  <Image
+                    src={preview}
+                    alt="Preview"
+                    borderRadius="md"
+                    cursor="pointer"
+                    boxSize="100px"
+                    objectFit="cover"
+                    onClick={() => setIsPreviewOpen(true)}
+                  />
+                  <IconButton
+                    aria-label="Discard image"
+                    size="xs"
                     bg="primaryText"
                     color="background"
                     _hover={{ bg: "primaryText", color: "background" }}
                     _active={{ bg: "primaryText", color: "background" }}
-                    _focus={{ bg: "primaryText", color: "background" }} />
-                  <ModalBody p={0}>
-                    <Image
-                      src={preview}
-                      alt="Preview"
-                      w="100%"
-                      maxH="80vh"
-                      objectFit="contain"
-                    />
-                  </ModalBody>
-                </ModalContent>
-              </Modal>
-            </>
-          )}
+                    _focus={{ bg: "primaryText", color: "background" }}
+                    icon={<IoMdClose />}
+                    variant="solid"
+                    position="absolute"
+                    top={1}
+                    right={1}
+                    isRound={true}
+                    onClick={handleDiscard}
+                  />
+                </Box>
+                <ImageModal
+                  isOpen={isPreviewOpen}
+                  onClose={() => setIsPreviewOpen(false)}
+                  src={preview}
+                  alt="Preview"
+                />
+              </>
+            )}
           <input
             type="file"
             accept="image/*"

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -17,12 +17,8 @@ import {
   IconButton,
   BoxProps,
   useColorMode,
-  Modal,
-  ModalOverlay,
-  ModalCloseButton,
-  ModalBody,
 } from "@chakra-ui/react";
-import { ModalContent } from "@themed-components";
+import { ImageModal } from "@themed-components";
 import { useTheme, useToastStore } from "@/stores";
 
 interface Message {
@@ -106,51 +102,27 @@ const MessageItem: FC<MessageItemProps> = ({
           alignItems={isUser ? "flex-end" : "flex-start"}
           gap={1}
         >
-          {message.image && (
-            <>
-              <Image
-                src={message.image.url}
-                id={message.image.id}
-                alt={message.image.id}
-                mt={2}
-                maxW={200}
-                rounded="md"
-                cursor="pointer"
-                onClick={() => setIsImageOpen(true)}
-              />
-              <Modal
-                isOpen={isImageOpen}
-                onClose={() => setIsImageOpen(false)}
-                isCentered
-                size="xl"
-                motionPreset="none"
-              >
-                <ModalOverlay />
-                <ModalContent>
-                  <ModalCloseButton
-                    position="fixed"
-                    top={4}
-                    right={4}
-                    borderRadius="full"
-                    bg="primaryText"
-                    color="background"
-                    _hover={{ bg: "primaryText", color: "background" }}
-                    _active={{ bg: "primaryText", color: "background" }}
-                    _focus={{ bg: "primaryText", color: "background" }}
-                  />
-                  <ModalBody p={0}>
-                    <Image
-                      src={message.image.url}
-                      alt={message.image.id}
-                      w="100%"
-                      maxH="80vh"
-                      objectFit="contain"
-                    />
-                  </ModalBody>
-                </ModalContent>
-              </Modal>
-            </>
-          )}
+            {message.image && (
+              <>
+                <Image
+                  src={message.image.url}
+                  id={message.image.id}
+                  alt={message.image.id}
+                  mt={2}
+                  boxSize="200px"
+                  objectFit="cover"
+                  rounded="md"
+                  cursor="pointer"
+                  onClick={() => setIsImageOpen(true)}
+                />
+                <ImageModal
+                  isOpen={isImageOpen}
+                  onClose={() => setIsImageOpen(false)}
+                  src={message.image.url}
+                  alt={message.image.id}
+                />
+              </>
+            )}
           {message.text && (
             <Box
               p={3}

--- a/src/components/ui/ImageModal/index.tsx
+++ b/src/components/ui/ImageModal/index.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { FC } from "react";
+import {
+  Modal,
+  ModalOverlay,
+  ModalCloseButton,
+  ModalBody,
+  type ModalProps,
+  Image,
+} from "@chakra-ui/react";
+import ModalContent from "../ModalContent";
+
+interface ImageModalProps extends Omit<ModalProps, "children"> {
+  src: string;
+  alt: string;
+}
+
+const ImageModal: FC<ImageModalProps> = ({ src, alt, ...props }) => {
+  return (
+    <Modal
+      isCentered
+      size="xl"
+      motionPreset="none"
+      closeOnOverlayClick={false}
+      {...props}
+    >
+      <ModalOverlay bgColor="background" />
+      <ModalContent>
+        <ModalCloseButton
+          position="fixed"
+          top={4}
+          right={4}
+          borderRadius="full"
+          bg="primaryText"
+          color="background"
+          _hover={{ bg: "primaryText", color: "background" }}
+          _active={{ bg: "primaryText", color: "background" }}
+          _focus={{ bg: "primaryText", color: "background" }}
+        />
+        <ModalBody p={0}>
+          <Image src={src} alt={alt} w="100%" maxH="80vh" objectFit="contain" />
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default ImageModal;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -7,6 +7,7 @@ import AlertDialogContent from "./AlertDialogContent";
 import ModalContent from "./ModalContent";
 import MenuItem from "./MenuItem";
 import MenuList from "./MenuList";
+import ImageModal from "./ImageModal";
 
 export {
   Button,
@@ -18,4 +19,5 @@ export {
   ModalContent,
   MenuItem,
   MenuList,
+  ImageModal,
 };


### PR DESCRIPTION
## Summary
- extract reusable `ImageModal` component and use for message previews
- ensure preview thumbnails are square by using `boxSize`
- configure modal overlay and overlay click behavior

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npx tsc --noEmit --diagnostics`


------
https://chatgpt.com/codex/tasks/task_e_68a003f2234c8327b37ee69134886ae2