### PR TITLE
Center image in full-screen ImageModal

### DIFF
--- a/src/components/ui/ImageModal/index.tsx
+++ b/src/components/ui/ImageModal/index.tsx
@@ -20,13 +20,13 @@ const ImageModal: FC<ImageModalProps> = ({ src, alt, ...props }) => {
   return (
     <Modal
       isCentered
-      size="xl"
+      size="full"
       motionPreset="none"
       closeOnOverlayClick={false}
       {...props}
     >
       <ModalOverlay bgColor="background" />
-      <ModalContent>
+      <ModalContent h="full">
         <ModalCloseButton
           position="fixed"
           top={4}
@@ -34,8 +34,19 @@ const ImageModal: FC<ImageModalProps> = ({ src, alt, ...props }) => {
           borderRadius="full"
           color="primaryText"
         />
-        <ModalBody p={0}>
-          <Image src={src} alt={alt} w="100%" maxH="80vh" objectFit="contain" />
+        <ModalBody
+          p={0}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Image
+            src={src}
+            alt={alt}
+            maxW="100%"
+            maxH="80vh"
+            objectFit="contain"
+          />
         </ModalBody>
       </ModalContent>
     </Modal>

--- a/src/components/ui/ImageModal/index.tsx
+++ b/src/components/ui/ImageModal/index.tsx
@@ -21,12 +21,11 @@ const ImageModal: FC<ImageModalProps> = ({ src, alt, ...props }) => {
     <Modal
       isCentered
       size="full"
-      motionPreset="none"
       closeOnOverlayClick={false}
       {...props}
     >
-      <ModalOverlay bgColor="background" />
-      <ModalContent h="full">
+      <ModalOverlay />
+      <ModalContent h="full" bgColor="background">
         <ModalCloseButton
           position="fixed"
           top={4}
@@ -44,7 +43,7 @@ const ImageModal: FC<ImageModalProps> = ({ src, alt, ...props }) => {
             src={src}
             alt={alt}
             maxW="100%"
-            maxH="80vh"
+            maxH="70vh"
             objectFit="contain"
           />
         </ModalBody>


### PR DESCRIPTION
## Summary
- center image within ImageModal using flex layout
- expand modal to full-screen for larger preview

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a01e0245648327ac55cf8e2e7cc8a0