### PR TITLE
Add attachment menu to message input

### DIFF
--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -7,21 +7,22 @@ import {
   useImperativeHandle,
 } from "react";
 import {
-    Flex,
-    IconButton,
-    Card,
-    Tooltip,
-    Divider,
-    Box,
-    Image,
-    InputLeftElement,
-    Menu,
-    MenuButton,
-  } from "@chakra-ui/react";
-import { IoStop, IoAddCircleSharp, IoImageOutline } from "react-icons/io5";
-import { IoIosMic, IoMdSend, IoMdClose } from "react-icons/io";
+  Flex,
+  IconButton,
+  Card,
+  Tooltip,
+  Divider,
+  Box,
+  Image,
+  InputLeftElement,
+  Menu,
+  MenuButton,
+  Icon,
+} from "@chakra-ui/react";
+import { IoStop, IoAddCircleSharp } from "react-icons/io5";
+import { IoIosMic, IoMdSend, IoMdClose, IoMdImage } from "react-icons/io";
 import { SpeechRecognize } from "@/lib";
-  import { Input, ImageModal, MenuList, MenuItem, InputGroup } from "@themed-components";
+import { Input, ImageModal, MenuList, MenuItem, InputGroup } from "@themed-components";
 
 export interface MessageInputHandle {
   handleFile: (file: File) => void;
@@ -111,43 +112,43 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       <Fragment>
         <Divider orientation="horizontal" />
         <Card p={3} borderRadius={0} variant="surface">
-            {preview && (
-              <>
-                <Box position="relative" boxSize="100px" mb={3}>
-                  <Image
-                    src={preview}
-                    alt="Preview"
-                    borderRadius="md"
-                    cursor="pointer"
-                    boxSize="100px"
-                    objectFit="cover"
-                    onClick={() => setIsPreviewOpen(true)}
-                  />
-                  <IconButton
-                    aria-label="Discard image"
-                    size="xs"
-                    bg="primaryText"
-                    color="background"
-                    _hover={{ bg: "primaryText", color: "background" }}
-                    _active={{ bg: "primaryText", color: "background" }}
-                    _focus={{ bg: "primaryText", color: "background" }}
-                    icon={<IoMdClose />}
-                    variant="solid"
-                    position="absolute"
-                    top={1}
-                    right={1}
-                    isRound={true}
-                    onClick={handleDiscard}
-                  />
-                </Box>
-                <ImageModal
-                  isOpen={isPreviewOpen}
-                  onClose={() => setIsPreviewOpen(false)}
+          {preview && (
+            <>
+              <Box position="relative" boxSize="100px" mb={3}>
+                <Image
                   src={preview}
                   alt="Preview"
+                  borderRadius="md"
+                  cursor="pointer"
+                  boxSize="100px"
+                  objectFit="cover"
+                  onClick={() => setIsPreviewOpen(true)}
                 />
-              </>
-            )}
+                <IconButton
+                  aria-label="Discard image"
+                  size="xs"
+                  bg="primaryText"
+                  color="background"
+                  _hover={{ bg: "primaryText", color: "background" }}
+                  _active={{ bg: "primaryText", color: "background" }}
+                  _focus={{ bg: "primaryText", color: "background" }}
+                  icon={<IoMdClose />}
+                  variant="solid"
+                  position="absolute"
+                  top={1}
+                  right={1}
+                  isRound={true}
+                  onClick={handleDiscard}
+                />
+              </Box>
+              <ImageModal
+                isOpen={isPreviewOpen}
+                onClose={() => setIsPreviewOpen(false)}
+                src={preview}
+                alt="Preview"
+              />
+            </>
+          )}
           <input
             type="file"
             accept="image/*"
@@ -155,44 +156,44 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
             style={{ display: "none" }}
             onChange={handleImageChange}
           />
-            <Flex gap={2} justify="center" align="center">
-              <InputGroup flex="1">
-                <InputLeftElement pointerEvents="auto">
-                  <Menu isLazy lazyBehavior="unmount">
-                    <Tooltip label="Add options">
-                      <MenuButton
-                        as={IconButton}
-                        aria-label="Add options"
-                        variant="ghost"
-                        icon={<IoAddCircleSharp />}
-                        isDisabled={isDisabled}
-                      />
-                    </Tooltip>
-                    <MenuList>
-                      <MenuItem
-                        icon={<IoImageOutline />}
-                        onClick={() => fileInputRef.current?.click()}
-                      >
-                        Upload image
-                      </MenuItem>
-                    </MenuList>
-                  </Menu>
-                </InputLeftElement>
-                <Input
-                  leftElement
-                  value={input}
-                  onChange={(e) => setInput(e.target.value)}
-                  onKeyDown={async (e) => {
-                    if (e.key === "Enter" && !e.shiftKey) {
-                      e.preventDefault();
-                      await handleSend();
-                    }
-                  }}
-                  placeholder="Write a message..."
-                  variant="filled"
-                  isDisabled={isDisabled}
-                />
-              </InputGroup>
+          <Flex gap={2} justify="center" align="center">
+            <InputGroup flex="1">
+              <InputLeftElement pointerEvents="auto">
+                <Menu isLazy lazyBehavior="unmount">
+                  <Tooltip label="Add options">
+                    <MenuButton
+                      as={IconButton}
+                      aria-label="Add options"
+                      variant="ghost"
+                      icon={<IoAddCircleSharp />}
+                      isDisabled={isDisabled}
+                    />
+                  </Tooltip>
+                  <MenuList>
+                    <MenuItem
+                      icon={<Icon as={IoMdImage} boxSize={4} />}
+                      onClick={() => fileInputRef.current?.click()}
+                    >
+                      Upload image
+                    </MenuItem>
+                  </MenuList>
+                </Menu>
+              </InputLeftElement>
+              <Input
+                leftElement
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={async (e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    await handleSend();
+                  }
+                }}
+                placeholder="Write a message..."
+                variant="filled"
+                isDisabled={isDisabled}
+              />
+            </InputGroup>
             <Tooltip label={isListening ? "Stop" : "Type by voice"}>
               <IconButton
                 aria-label="Speech Recognition"

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -14,15 +14,14 @@ import {
     Divider,
     Box,
     Image,
-    InputGroup,
     InputLeftElement,
     Menu,
     MenuButton,
   } from "@chakra-ui/react";
-import { IoStop, IoAddCircleSharp } from "react-icons/io5";
+import { IoStop, IoAddCircleSharp, IoImageOutline } from "react-icons/io5";
 import { IoIosMic, IoMdSend, IoMdClose } from "react-icons/io";
 import { SpeechRecognize } from "@/lib";
-  import { Input, ImageModal, MenuList, MenuItem } from "@themed-components";
+  import { Input, ImageModal, MenuList, MenuItem, InputGroup } from "@themed-components";
 
 export interface MessageInputHandle {
   handleFile: (file: File) => void;
@@ -160,15 +159,20 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
               <InputGroup flex="1">
                 <InputLeftElement pointerEvents="auto">
                   <Menu>
-                    <MenuButton
-                      as={IconButton}
-                      aria-label="Add options"
-                      variant="ghost"
-                      icon={<IoAddCircleSharp />}
-                      isDisabled={isDisabled}
-                    />
+                    <Tooltip label="Add options">
+                      <MenuButton
+                        as={IconButton}
+                        aria-label="Add options"
+                        variant="ghost"
+                        icon={<IoAddCircleSharp />}
+                        isDisabled={isDisabled}
+                      />
+                    </Tooltip>
                     <MenuList>
-                      <MenuItem onClick={() => fileInputRef.current?.click()}>
+                      <MenuItem
+                        icon={<IoImageOutline />}
+                        onClick={() => fileInputRef.current?.click()}
+                      >
                         Upload image
                       </MenuItem>
                     </MenuList>

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -158,7 +158,7 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
             <Flex gap={2} justify="center" align="center">
               <InputGroup flex="1">
                 <InputLeftElement pointerEvents="auto">
-                  <Menu>
+                  <Menu isLazy lazyBehavior="unmount">
                     <Tooltip label="Add options">
                       <MenuButton
                         as={IconButton}

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -14,11 +14,15 @@ import {
     Divider,
     Box,
     Image,
+    InputGroup,
+    InputLeftElement,
+    Menu,
+    MenuButton,
   } from "@chakra-ui/react";
-import { IoStop } from "react-icons/io5";
-import { IoIosMic, IoMdImage, IoMdSend, IoMdClose } from "react-icons/io";
+import { IoStop, IoAddCircleSharp } from "react-icons/io5";
+import { IoIosMic, IoMdSend, IoMdClose } from "react-icons/io";
 import { SpeechRecognize } from "@/lib";
-  import { Input, ImageModal } from "@themed-components";
+  import { Input, ImageModal, MenuList, MenuItem } from "@themed-components";
 
 export interface MessageInputHandle {
   handleFile: (file: File) => void;
@@ -152,30 +156,39 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
             style={{ display: "none" }}
             onChange={handleImageChange}
           />
-          <Flex gap={2} justify="center" align="center">
-            <Input
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={async (e) => {
-                if (e.key === "Enter" && !e.shiftKey) {
-                  e.preventDefault();
-                  await handleSend();
-                }
-              }}
-              placeholder="Write a message..."
-              flex="1"
-              variant="filled"
-              isDisabled={isDisabled}
-            />
-            <Tooltip label="Upload image">
-              <IconButton
-                aria-label="Upload image"
-                variant="ghost"
-                icon={<IoMdImage />}
-                onClick={() => fileInputRef.current?.click()}
-                isDisabled={isDisabled}
-              />
-            </Tooltip>
+            <Flex gap={2} justify="center" align="center">
+              <InputGroup flex="1">
+                <InputLeftElement pointerEvents="auto">
+                  <Menu>
+                    <MenuButton
+                      as={IconButton}
+                      aria-label="Add options"
+                      variant="ghost"
+                      icon={<IoAddCircleSharp />}
+                      isDisabled={isDisabled}
+                    />
+                    <MenuList>
+                      <MenuItem onClick={() => fileInputRef.current?.click()}>
+                        Upload image
+                      </MenuItem>
+                    </MenuList>
+                  </Menu>
+                </InputLeftElement>
+                <Input
+                  leftElement
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={async (e) => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault();
+                      await handleSend();
+                    }
+                  }}
+                  placeholder="Write a message..."
+                  variant="filled"
+                  isDisabled={isDisabled}
+                />
+              </InputGroup>
             <Tooltip label={isListening ? "Stop" : "Type by voice"}>
               <IconButton
                 aria-label="Speech Recognition"

--- a/src/components/ui/InputGroup/index.tsx
+++ b/src/components/ui/InputGroup/index.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { forwardRef } from "react";
+import { InputGroup as ChakraInputGroup, type InputGroupProps } from "@chakra-ui/react";
+import { useTheme } from "@/stores";
+
+const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>((props, ref) => {
+  const { colorScheme } = useTheme();
+  return <ChakraInputGroup ref={ref} colorScheme={colorScheme} {...props} />;
+});
+
+InputGroup.displayName = "InputGroup";
+
+export default InputGroup;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,5 +1,6 @@
 import Button from "./Button";
 import Input from "./Input";
+import InputGroup from "./InputGroup";
 import Progress from "./Progress";
 import Spinner from "./Spinner";
 import Toast from "./Toast";
@@ -12,6 +13,7 @@ import ImageModal from "./ImageModal";
 export {
   Button,
   Input,
+  InputGroup,
   Progress,
   Spinner,
   Toast,


### PR DESCRIPTION
## Summary
- swap image icon for IoAddCircleSharp add icon
- show menu with Upload image option from input's left side

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a04dd164ec8327bfd26036933fe2fb