### PR TITLE
Replace dark mode toggle with theme select

### DIFF
--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -19,22 +19,15 @@ import {
   ModalCloseButton,
   FormControl,
   FormLabel,
-  Menu,
-  MenuButton,
 } from "@chakra-ui/react";
 import { IoSettings, IoSettingsOutline } from "react-icons/io5";
 import { MdOutlineColorLens, MdColorLens, MdInfoOutline, MdInfo } from "react-icons/md";
-import { ModalContent, Button, MenuItem, MenuList } from "@themed-components";
+import { ModalContent, Select } from "@themed-components";
 import { useTheme } from "@/stores";
 import { HiOutlineSpeakerWave, HiSpeakerWave, HiUser } from "react-icons/hi2";
 import { BiMessageDetail, BiSolidMessageDetail } from "react-icons/bi";
 import { TbArrowBigUpLines, TbArrowBigUpLinesFilled } from "react-icons/tb";
-import {
-  HiLockClosed,
-  HiOutlineChevronDown,
-  HiOutlineLockClosed,
-  HiOutlineUser,
-} from "react-icons/hi";
+import { HiLockClosed, HiOutlineLockClosed, HiOutlineUser } from "react-icons/hi";
 
 interface SettingsProps {
   isOpen: boolean;
@@ -81,11 +74,6 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
     } as const;
     return palette[state];
   };
-
-  const modeLabel =
-    mode === "system"
-      ? "System default"
-      : mode.charAt(0).toUpperCase() + mode.slice(1);
 
   const tabs = [
     {
@@ -224,26 +212,15 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
                 <Flex direction="column" maxW="sm" gap={4}>
                   <FormControl>
                     <FormLabel>Theme</FormLabel>
-                    <Menu>
-                      <MenuButton
-                        as={Button}
-                        rightIcon={<HiOutlineChevronDown />}
-                        variant="outline"
-                      >
-                        {modeLabel}
-                      </MenuButton>
-                      <MenuList>
-                        <MenuItem onClick={() => handleColorModeChange("light")}>
-                          Light
-                        </MenuItem>
-                        <MenuItem onClick={() => handleColorModeChange("dark")}>
-                          Dark
-                        </MenuItem>
-                        <MenuItem onClick={() => handleColorModeChange("system")}>
-                          System default
-                        </MenuItem>
-                      </MenuList>
-                    </Menu>
+                    <Select
+                      value={mode}
+                      onChange={handleColorModeChange}
+                      options={[
+                        { label: "Light", value: "light" },
+                        { label: "Dark", value: "dark" },
+                        { label: "System default", value: "system" },
+                      ]}
+                    />
                   </FormControl>
                 </Flex>
               </TabPanel>

--- a/src/components/ui/Select/index.tsx
+++ b/src/components/ui/Select/index.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { FC } from "react";
+import {
+  Menu,
+  MenuButton,
+  useColorMode,
+  type MenuProps,
+} from "@chakra-ui/react";
+import { HiOutlineChevronDown } from "react-icons/hi";
+import Button from "../Button";
+import MenuItem from "../MenuItem";
+import MenuList from "../MenuList";
+
+interface Option {
+  label: string;
+  value: string;
+}
+
+interface SelectProps extends Omit<MenuProps, "children"> {
+  value: string;
+  options: Option[];
+  onChange: (value: string) => void;
+}
+
+const Select: FC<SelectProps> = ({ value, options, onChange, ...menuProps }) => {
+  const { colorMode } = useColorMode();
+  const selectedLabel = options.find((o) => o.value === value)?.label ?? "";
+  const selectedBg = colorMode === "dark" ? "gray.700" : "gray.100";
+
+  return (
+    <Menu {...menuProps}>
+      <MenuButton as={Button} rightIcon={<HiOutlineChevronDown />} variant="outline">
+        {selectedLabel}
+      </MenuButton>
+      <MenuList>
+        {options.map((opt) => (
+          <MenuItem
+            key={opt.value}
+            onClick={() => onChange(opt.value)}
+            bgColor={value === opt.value ? selectedBg : undefined}
+          >
+            {opt.label}
+          </MenuItem>
+        ))}
+      </MenuList>
+    </Menu>
+  );
+};
+
+export default Select;
+

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -9,6 +9,7 @@ import ModalContent from "./ModalContent";
 import MenuItem from "./MenuItem";
 import MenuList from "./MenuList";
 import ImageModal from "./ImageModal";
+import Select from "./Select";
 
 export {
   Button,
@@ -22,4 +23,5 @@ export {
   MenuItem,
   MenuList,
   ImageModal,
+  Select,
 };


### PR DESCRIPTION
## Summary
- replace dark mode switch in settings with select offering light, dark, or system theme
- add reusable Select component to UI library

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0640501108327bf59222a31724aa3