### PR TITLE
feat: add theme select component

### DIFF
--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -19,11 +19,10 @@ import {
   ModalCloseButton,
   FormControl,
   FormLabel,
-  Switch,
 } from "@chakra-ui/react";
 import { IoSettings, IoSettingsOutline } from "react-icons/io5";
 import { MdOutlineColorLens, MdColorLens, MdInfoOutline, MdInfo } from "react-icons/md";
-import { ModalContent } from "@themed-components";
+import { ModalContent, Select } from "@themed-components";
 import { useTheme } from "@/stores";
 import { HiOutlineSpeakerWave, HiSpeakerWave, HiUser } from "react-icons/hi2";
 import { BiMessageDetail, BiSolidMessageDetail } from "react-icons/bi";
@@ -36,9 +35,16 @@ interface SettingsProps {
 }
 
 const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
-  const { colorMode, toggleColorMode } = useColorMode();
+  const { colorMode, setColorMode } = useColorMode();
   const { colorScheme } = useTheme();
   const [tabIndex, setTabIndex] = useState(0);
+  const [mode, setMode] = useState<"light" | "dark" | "system">(
+    (typeof window !== "undefined" &&
+      (localStorage.getItem("color-mode-preference") as
+        | "light"
+        | "dark"
+        | "system")) || colorMode
+  );
   const tabListRef = useRef<HTMLDivElement>(null);
   const isMobile = useBreakpointValue({ base: true, md: false }) ?? false;
 
@@ -193,16 +199,41 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
             <TabPanels flex="1" minH={0} overflowY="auto">
               <TabPanel>General settings go here.</TabPanel>
               <TabPanel>
-                <FormControl display="flex" alignItems="center">
-                  <FormLabel htmlFor="color-mode-toggle" mb="0">
-                    Dark Mode
-                  </FormLabel>
-                  <Switch
-                    id="color-mode-toggle"
-                    isChecked={colorMode === "dark"}
-                    onChange={toggleColorMode}
-                  />
-                </FormControl>
+                <Flex direction="column" gap={4} maxW="xs">
+                  <FormControl>
+                    <FormLabel htmlFor="color-mode-select" mb="0">
+                      Theme
+                    </FormLabel>
+                    <Select
+                      id="color-mode-select"
+                      value={mode}
+                      onChange={(e) => {
+                        const value = e.target.value as
+                          | "light"
+                          | "dark"
+                          | "system";
+                        setMode(value);
+                        localStorage.setItem("color-mode-preference", value);
+                        if (value === "system") {
+                          const system = window.matchMedia(
+                            "(prefers-color-scheme: dark)"
+                          ).matches
+                            ? "dark"
+                            : "light";
+                          setColorMode(system);
+                        } else {
+                          setColorMode(value);
+                        }
+                      }}
+                    >
+                      <Select.Option value="light">Light</Select.Option>
+                      <Select.Option value="dark">Dark</Select.Option>
+                      <Select.Option value="system">
+                        System Default
+                      </Select.Option>
+                    </Select>
+                  </FormControl>
+                </Flex>
               </TabPanel>
               <TabPanel>Chat preferences go here.</TabPanel>
               <TabPanel>Data & Privacy settings go here.</TabPanel>

--- a/src/components/ui/Select/index.tsx
+++ b/src/components/ui/Select/index.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { forwardRef } from "react";
+import {
+  Select as ChakraSelect,
+  chakra,
+  useColorMode,
+  type SelectProps,
+  type HTMLChakraProps,
+} from "@chakra-ui/react";
+import { useTheme } from "@/stores";
+
+const Option = forwardRef<HTMLOptionElement, HTMLChakraProps<"option">>(
+  (props, ref) => {
+    const { colorMode } = useColorMode();
+    return (
+      <chakra.option
+        ref={ref}
+        bgColor={colorMode === "light" ? "surface" : "mutedSurface"}
+        _hover={{
+          bgColor: colorMode === "dark" ? "gray.800" : "gray.100",
+        }}
+        _active={{
+          bgColor: colorMode === "dark" ? "gray.700" : "gray.200",
+        }}
+        _focus={{
+          bgColor: colorMode === "dark" ? "gray.700" : "gray.100",
+        }}
+        {...props}
+      />
+    );
+  }
+);
+
+Option.displayName = "Option";
+
+const BaseSelect = forwardRef<HTMLSelectElement, SelectProps>((props, ref) => {
+  const { colorMode } = useColorMode();
+  const { colorScheme } = useTheme();
+
+  const focusBorderColor =
+    colorMode === "dark" ? `${colorScheme}.300` : `${colorScheme}.400`;
+
+  return (
+    <ChakraSelect
+      ref={ref}
+      bgColor={colorMode === "light" ? "surface" : "mutedSurface"}
+      focusBorderColor={focusBorderColor}
+      _hover={{ borderColor: focusBorderColor }}
+      {...props}
+    />
+  );
+});
+
+BaseSelect.displayName = "Select";
+
+const Select = Object.assign(BaseSelect, { Option });
+
+export default Select;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -9,6 +9,7 @@ import ModalContent from "./ModalContent";
 import MenuItem from "./MenuItem";
 import MenuList from "./MenuList";
 import ImageModal from "./ImageModal";
+import Select from "./Select";
 
 export {
   Button,
@@ -22,4 +23,5 @@ export {
   MenuItem,
   MenuList,
   ImageModal,
+  Select,
 };


### PR DESCRIPTION
## Summary
- add reusable Select component with custom styled options
- replace dark mode toggle with theme select and improved layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a06b19c2988327b3430db76e56d81a