### PR TITLE
Add outline theme selector and remove navbar toggle

### DIFF
--- a/src/components/NavigationBar/index.tsx
+++ b/src/components/NavigationBar/index.tsx
@@ -5,12 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 
 import { HiOutlineChevronDown } from "react-icons/hi";
 import { IoMdMenu } from "react-icons/io";
-import {
-  RiChat3Line,
-  RiChatHistoryFill,
-  RiMoonFill,
-  RiSunFill,
-} from "react-icons/ri";
+import { RiChat3Line, RiChatHistoryFill } from "react-icons/ri";
 
 import {
   Card,
@@ -20,7 +15,6 @@ import {
   Menu,
   MenuButton,
   Text,
-  useColorMode,
   useDisclosure,
 } from "@chakra-ui/react";
 
@@ -34,7 +28,6 @@ interface Thread {
 }
 
 const NavigationBar: FC = () => {
-  const { colorMode, toggleColorMode } = useColorMode();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { user, loading: authLoading } = useAuth();
   const pathname = usePathname();
@@ -190,12 +183,6 @@ const NavigationBar: FC = () => {
                 onClick={toggleTemporaryChat}
               />
             )}
-            <IconButton
-              aria-label="Toggle Dark Mode"
-              icon={colorMode === "light" ? <RiMoonFill /> : <RiSunFill />}
-              onClick={toggleColorMode}
-              variant="ghost"
-            />
             {!user && <Button onClick={handleGoogleSignIn}>Login</Button>}
           </Flex>
         </Flex>

--- a/src/components/Settings/Appearance.tsx
+++ b/src/components/Settings/Appearance.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { FC, useState } from "react";
+import { Button, Flex, Icon, useColorMode } from "@chakra-ui/react";
+import { useTheme } from "@/stores";
+import {
+  RiSunLine,
+  RiMoonLine,
+  RiComputerLine,
+  RiSunFill,
+  RiMoonFill,
+  RiComputerFill,
+} from "react-icons/ri";
+
+const Appearance: FC = () => {
+  const { setColorMode } = useColorMode();
+  const { colorScheme } = useTheme();
+  const [mode, setMode] = useState<"light" | "dark" | "system">(() => {
+    if (typeof window !== "undefined") {
+      return (
+        (localStorage.getItem("chakra-ui-color-mode") as
+          | "light"
+          | "dark"
+          | "system") || "light"
+      );
+    }
+    return "light";
+  });
+
+  const handleColorModeChange = (value: "light" | "dark" | "system") => {
+    setMode(value);
+    setColorMode(value);
+  };
+
+  return (
+    <Flex direction="column" gap={3}>
+      <Flex direction="column" gap={1}>
+        <Flex fontWeight="semibold" fontSize="md">
+          Color Mode
+        </Flex>
+        <Flex fontSize="sm" color="secondaryText">
+          Select a preferred color mode, or let the app follow your system’s appearance setting
+        </Flex>
+      </Flex>
+
+      <Flex gap={2} mt={1} wrap="wrap">
+        {([
+          {
+            label: "Light",
+            value: "light",
+            icon: RiSunLine,
+            selectedIcon: RiSunFill,
+          },
+          {
+            label: "Dark",
+            value: "dark",
+            icon: RiMoonLine,
+            selectedIcon: RiMoonFill,
+          },
+          {
+            label: "System",
+            value: "system",
+            icon: RiComputerLine,
+            selectedIcon: RiComputerFill,
+          },
+        ] as const).map((item) => {
+          const isSelected = mode === item.value;
+          return (
+            <Button
+              key={item.value}
+              onClick={() => handleColorModeChange(item.value)}
+              variant="outline"
+              colorScheme={isSelected ? colorScheme : "gray"}
+              borderColor={isSelected ? `${colorScheme}.500` : "gray.300"}
+              bg={isSelected ? `${colorScheme}.50` : "transparent"}
+              _dark={{
+                borderColor: isSelected ? `${colorScheme}.300` : "gray.600",
+                bg: isSelected ? `${colorScheme}.900` : "transparent",
+              }}
+              leftIcon={
+                <Icon
+                  as={isSelected ? item.selectedIcon : item.icon}
+                  boxSize={4}
+                />
+              }
+            >
+              {item.label}
+            </Button>
+          );
+        })}
+      </Flex>
+    </Flex>
+  );
+};
+
+export default Appearance;
+

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -17,9 +17,7 @@ import {
   Flex,
   useBreakpointValue,
   ModalCloseButton,
-  FormControl,
-  FormLabel,
-  Switch,
+  Button,
 } from "@chakra-ui/react";
 import { IoSettings, IoSettingsOutline } from "react-icons/io5";
 import { MdOutlineColorLens, MdColorLens, MdInfoOutline, MdInfo } from "react-icons/md";
@@ -29,6 +27,7 @@ import { HiOutlineSpeakerWave, HiSpeakerWave, HiUser } from "react-icons/hi2";
 import { BiMessageDetail, BiSolidMessageDetail } from "react-icons/bi";
 import { TbArrowBigUpLines, TbArrowBigUpLinesFilled } from "react-icons/tb";
 import { HiLockClosed, HiOutlineLockClosed, HiOutlineUser } from "react-icons/hi";
+import { RiSunLine, RiMoonLine, RiComputerLine } from "react-icons/ri";
 
 interface SettingsProps {
   isOpen: boolean;
@@ -36,9 +35,20 @@ interface SettingsProps {
 }
 
 const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
-  const { colorMode, toggleColorMode } = useColorMode();
+  const { colorMode, setColorMode } = useColorMode();
   const { colorScheme } = useTheme();
   const [tabIndex, setTabIndex] = useState(0);
+  const [mode, setMode] = useState<"light" | "dark" | "system">(() => {
+    if (typeof window !== "undefined") {
+      return (
+        (localStorage.getItem("chakra-ui-color-mode") as
+          | "light"
+          | "dark"
+          | "system") || "light"
+      );
+    }
+    return "light";
+  });
   const tabListRef = useRef<HTMLDivElement>(null);
   const isMobile = useBreakpointValue({ base: true, md: false }) ?? false;
 
@@ -46,6 +56,11 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
     if (!isMobile) return;
     e.preventDefault();
     tabListRef.current?.scrollBy({ left: e.deltaY });
+  };
+
+  const handleColorModeChange = (value: "light" | "dark" | "system") => {
+    setMode(value);
+    setColorMode(value);
   };
 
   const getBg = (state: "base" | "hover" | "active" | "selected") => {
@@ -193,16 +208,32 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
             <TabPanels flex="1" minH={0} overflowY="auto">
               <TabPanel>General settings go here.</TabPanel>
               <TabPanel>
-                <FormControl display="flex" alignItems="center">
-                  <FormLabel htmlFor="color-mode-toggle" mb="0">
-                    Dark Mode
-                  </FormLabel>
-                  <Switch
-                    id="color-mode-toggle"
-                    isChecked={colorMode === "dark"}
-                    onChange={toggleColorMode}
-                  />
-                </FormControl>
+                <Flex gap={2} wrap="wrap">
+                  <Button
+                    leftIcon={<RiSunLine />}
+                    variant="outline"
+                    colorScheme={mode === "light" ? colorScheme : "gray"}
+                    onClick={() => handleColorModeChange("light")}
+                  >
+                    Light
+                  </Button>
+                  <Button
+                    leftIcon={<RiMoonLine />}
+                    variant="outline"
+                    colorScheme={mode === "dark" ? colorScheme : "gray"}
+                    onClick={() => handleColorModeChange("dark")}
+                  >
+                    Dark
+                  </Button>
+                  <Button
+                    leftIcon={<RiComputerLine />}
+                    variant="outline"
+                    colorScheme={mode === "system" ? colorScheme : "gray"}
+                    onClick={() => handleColorModeChange("system")}
+                  >
+                    System
+                  </Button>
+                </Flex>
               </TabPanel>
               <TabPanel>Chat preferences go here.</TabPanel>
               <TabPanel>Data & Privacy settings go here.</TabPanel>

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -17,7 +17,6 @@ import {
   Flex,
   useBreakpointValue,
   ModalCloseButton,
-  Button,
 } from "@chakra-ui/react";
 import { IoSettings, IoSettingsOutline } from "react-icons/io5";
 import { MdOutlineColorLens, MdColorLens, MdInfoOutline, MdInfo } from "react-icons/md";
@@ -27,7 +26,7 @@ import { HiOutlineSpeakerWave, HiSpeakerWave, HiUser } from "react-icons/hi2";
 import { BiMessageDetail, BiSolidMessageDetail } from "react-icons/bi";
 import { TbArrowBigUpLines, TbArrowBigUpLinesFilled } from "react-icons/tb";
 import { HiLockClosed, HiOutlineLockClosed, HiOutlineUser } from "react-icons/hi";
-import { RiSunLine, RiMoonLine, RiComputerLine } from "react-icons/ri";
+import Appearance from "./Appearance";
 
 interface SettingsProps {
   isOpen: boolean;
@@ -35,20 +34,9 @@ interface SettingsProps {
 }
 
 const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
-  const { colorMode, setColorMode } = useColorMode();
+  const { colorMode } = useColorMode();
   const { colorScheme } = useTheme();
   const [tabIndex, setTabIndex] = useState(0);
-  const [mode, setMode] = useState<"light" | "dark" | "system">(() => {
-    if (typeof window !== "undefined") {
-      return (
-        (localStorage.getItem("chakra-ui-color-mode") as
-          | "light"
-          | "dark"
-          | "system") || "light"
-      );
-    }
-    return "light";
-  });
   const tabListRef = useRef<HTMLDivElement>(null);
   const isMobile = useBreakpointValue({ base: true, md: false }) ?? false;
 
@@ -56,11 +44,6 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
     if (!isMobile) return;
     e.preventDefault();
     tabListRef.current?.scrollBy({ left: e.deltaY });
-  };
-
-  const handleColorModeChange = (value: "light" | "dark" | "system") => {
-    setMode(value);
-    setColorMode(value);
   };
 
   const getBg = (state: "base" | "hover" | "active" | "selected") => {
@@ -208,36 +191,13 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
             <TabPanels flex="1" minH={0} overflowY="auto">
               <TabPanel>General settings go here.</TabPanel>
               <TabPanel>
-                <Flex gap={2} wrap="wrap">
-                  <Button
-                    leftIcon={<RiSunLine />}
-                    variant="outline"
-                    colorScheme={mode === "light" ? colorScheme : "gray"}
-                    onClick={() => handleColorModeChange("light")}
-                  >
-                    Light
-                  </Button>
-                  <Button
-                    leftIcon={<RiMoonLine />}
-                    variant="outline"
-                    colorScheme={mode === "dark" ? colorScheme : "gray"}
-                    onClick={() => handleColorModeChange("dark")}
-                  >
-                    Dark
-                  </Button>
-                  <Button
-                    leftIcon={<RiComputerLine />}
-                    variant="outline"
-                    colorScheme={mode === "system" ? colorScheme : "gray"}
-                    onClick={() => handleColorModeChange("system")}
-                  >
-                    System
-                  </Button>
-                </Flex>
+                <Appearance />
               </TabPanel>
+              <TabPanel>Voice & Accessibility settings go here.</TabPanel>
               <TabPanel>Chat preferences go here.</TabPanel>
               <TabPanel>Data & Privacy settings go here.</TabPanel>
               <TabPanel>Account settings go here.</TabPanel>
+              <TabPanel>Advanced settings go here.</TabPanel>
               <TabPanel>About info goes here.</TabPanel>
             </TabPanels>
           </Tabs>


### PR DESCRIPTION
## Summary
- Replace appearance settings switch with outline buttons for light, dark and system modes
- Remove light/dark toggle button from the navigation bar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a07e64c7c08327a26d143f15807598