### PR TITLE
Fix tab panel scroll blocked by sidebar

### DIFF
--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -416,6 +416,8 @@ const SideBar: FC<SideBarProps> = ({ type, isOpen, placement, onClose }) => {
           placement={placement!}
           onClose={onClose!}
           size="xs"
+          // Allow the underlying content (like TabPanels) to remain scrollable
+          blockScrollOnMount={false}
         >
           <DrawerOverlay />
           <DrawerContent>


### PR DESCRIPTION
## Summary
- allow scrolling while sidebar drawer is open by disabling scroll locking

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b09e62ac8327a320e9736a2dd599