### PR TITLE
refactor: rename useTheme to useAccentColor

### DIFF
--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -19,7 +19,7 @@ import {
   useColorMode,
 } from "@chakra-ui/react";
 import { ImageModal } from "@themed-components";
-import { useTheme, useToastStore } from "@/stores";
+import { useAccentColor, useToastStore } from "@/stores";
 
 interface Message {
   text: string | null;
@@ -61,7 +61,7 @@ const MessageItem: FC<MessageItemProps> = ({
       locale: enUS,
     });
 
-  const { colorScheme } = useTheme();
+    const { colorScheme } = useAccentColor();
   const { colorMode } = useColorMode();
   const { showToast } = useToastStore();
   const [copied, setCopied] = useState(false);

--- a/src/components/Settings/Appearance.tsx
+++ b/src/components/Settings/Appearance.tsx
@@ -2,7 +2,7 @@
 
 import { FC, useEffect, useState } from "react";
 import { Button, Flex, Icon, useColorMode } from "@chakra-ui/react";
-import { useTheme, useAuth } from "@/stores";
+import { useAccentColor, useAuth } from "@/stores";
 import { supabase } from "@/lib";
 import {
   RiSunLine,
@@ -15,7 +15,7 @@ import {
 
 const Appearance: FC = () => {
   const { setColorMode } = useColorMode();
-  const { colorScheme } = useTheme();
+  const { colorScheme } = useAccentColor();
   const { user } = useAuth();
 
   const [mode, setMode] = useState<"light" | "dark" | "system">(() => {

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -21,7 +21,7 @@ import {
 import { IoSettings, IoSettingsOutline } from "react-icons/io5";
 import { MdOutlineColorLens, MdColorLens, MdInfoOutline, MdInfo } from "react-icons/md";
 import { ModalContent } from "@themed-components";
-import { useTheme } from "@/stores";
+import { useAccentColor } from "@/stores";
 import { HiOutlineSpeakerWave, HiSpeakerWave, HiUser } from "react-icons/hi2";
 import { BiMessageDetail, BiSolidMessageDetail } from "react-icons/bi";
 import { TbArrowBigUpLines, TbArrowBigUpLinesFilled } from "react-icons/tb";
@@ -35,7 +35,7 @@ interface SettingsProps {
 
 const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
   const { colorMode } = useColorMode();
-  const { colorScheme } = useTheme();
+  const { colorScheme } = useAccentColor();
   const [tabIndex, setTabIndex] = useState(0);
   const tabListRef = useRef<HTMLDivElement>(null);
   const isMobile = useBreakpointValue({ base: true, md: false }) ?? false;

--- a/src/components/ThreadItem/index.tsx
+++ b/src/components/ThreadItem/index.tsx
@@ -30,7 +30,7 @@ import {
 } from "@themed-components";
 import { HiOutlineDotsVertical, HiPencil, HiTrash } from "react-icons/hi";
 import { RiArchive2Fill, RiPushpinFill, RiUnpinFill } from "react-icons/ri";
-import { useAuth, useTheme, useToastStore } from "@/stores";
+import { useAuth, useAccentColor, useToastStore } from "@/stores";
 import { ThreadWrapper } from "@/components";
 import { supabase } from "@/lib";
 
@@ -61,7 +61,7 @@ const ThreadItem: FC<ThreadItemProps> = ({
 }) => {
   const { colorMode } = useColorMode();
   const { user } = useAuth();
-  const { colorScheme } = useTheme();
+  const { colorScheme } = useAccentColor();
   const { showToast } = useToastStore();
   const router = useRouter();
   const pathname = usePathname();

--- a/src/components/ThreadList/index.tsx
+++ b/src/components/ThreadList/index.tsx
@@ -18,7 +18,7 @@ import { Box, Text, Flex } from "@chakra-ui/react";
 import { supabase } from "@/lib/supabase/client";
 import { formatNormalTime } from "@/utils/dateFormatter";
 import { Progress } from "@themed-components";
-import { useAuth, useTheme } from "@/stores";
+import { useAuth, useAccentColor } from "@/stores";
 import { ThreadItem } from "@/components";
 
 interface SearchResultItem {
@@ -58,7 +58,7 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm }) => {
   const [readyToRender, setReadyToRender] = useState(false);
   const [hasScrolledOnce, setHasScrolledOnce] = useState(false);
 
-  const { colorScheme } = useTheme();
+  const { colorScheme } = useAccentColor();
 
   const fetchMessages = useCallback(
     async (threadId: string): Promise<Message[]> => {

--- a/src/components/ui/Button/index.tsx
+++ b/src/components/ui/Button/index.tsx
@@ -2,10 +2,10 @@
 
 import { forwardRef } from "react";
 import { Button as ChakraButton, ButtonProps } from "@chakra-ui/react";
-import { useTheme } from "@/stores";
+import { useAccentColor } from "@/stores";
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
-  const { colorScheme } = useTheme();
+  const { colorScheme } = useAccentColor();
   return <ChakraButton ref={ref} colorScheme={colorScheme} {...props} />;
 });
 

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -6,7 +6,7 @@ import {
   InputProps,
   useColorMode,
 } from "@chakra-ui/react";
-import { useTheme } from "@/stores";
+import { useAccentColor } from "@/stores";
 
 interface CustomInputProps extends InputProps {
   leftElement?: ReactNode;
@@ -21,7 +21,7 @@ const Input: FC<CustomInputProps> = ({
   focusBorderColor,
   ...rest
 }) => {
-  const { colorScheme } = useTheme();
+  const { colorScheme } = useAccentColor();
   const { colorMode } = useColorMode();
 
   const computedFocusBorderColor =

--- a/src/components/ui/InputGroup/index.tsx
+++ b/src/components/ui/InputGroup/index.tsx
@@ -2,10 +2,10 @@
 
 import { forwardRef } from "react";
 import { InputGroup as ChakraInputGroup, type InputGroupProps } from "@chakra-ui/react";
-import { useTheme } from "@/stores";
+import { useAccentColor } from "@/stores";
 
 const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>((props, ref) => {
-  const { colorScheme } = useTheme();
+  const { colorScheme } = useAccentColor();
   return <ChakraInputGroup ref={ref} colorScheme={colorScheme} {...props} />;
 });
 

--- a/src/components/ui/Progress/index.tsx
+++ b/src/components/ui/Progress/index.tsx
@@ -2,10 +2,10 @@
 
 import { FC } from "react";
 import { Progress as ChakraProgress, ProgressProps } from "@chakra-ui/react";
-import { useTheme } from "@/stores";
+import { useAccentColor } from "@/stores";
 
 const Progress: FC<ProgressProps> = (props) => {
-  const { colorScheme } = useTheme();
+  const { colorScheme } = useAccentColor();
 
   return <ChakraProgress colorScheme={colorScheme} {...props} />;
 };

--- a/src/components/ui/Spinner/index.tsx
+++ b/src/components/ui/Spinner/index.tsx
@@ -6,10 +6,10 @@ import {
   SpinnerProps,
   useColorMode,
 } from "@chakra-ui/react";
-import { useTheme } from "@/stores";
+import { useAccentColor } from "@/stores";
 
 const Spinner: FC<SpinnerProps> = (props) => {
-  const { colorScheme } = useTheme();
+  const { colorScheme } = useAccentColor();
   const { colorMode } = useColorMode();
 
   const color =

--- a/src/layouts/Thread/layout.tsx
+++ b/src/layouts/Thread/layout.tsx
@@ -1,7 +1,7 @@
 import { FC, ReactNode, useState, useRef } from "react";
 import { Flex, Icon, Text, useColorMode } from "@chakra-ui/react";
 import { IoMdImage } from "react-icons/io";
-import { useTheme } from "@/stores";
+import { useAccentColor } from "@/stores";
 
 interface ThreadLayoutProps {
   children: ReactNode;
@@ -10,7 +10,7 @@ interface ThreadLayoutProps {
 
 const DropOverlay: FC = () => {
   const { colorMode } = useColorMode();
-  const { colorScheme } = useTheme();
+  const { colorScheme } = useAccentColor();
   const borderColor =
     colorMode === "dark" ? `${colorScheme}.300` : `${colorScheme}.500`;
 

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -2,7 +2,7 @@ export { default as useAuth } from "./auth/useAuth";
 export { default as useThreadMessages } from "./thread/useThreadMessages";
 export { default as useThreadInput } from "./thread/useThreadInput";
 export { default as useTempThread } from "./thread/useTempThread";
-export { default as useTheme } from "./theme/useTheme";
+export { default as useAccentColor } from "./theme/useAccentColor";
 export { default as useToastStore } from "./components/useToastStore";
 export { default as useModel } from "./model/useModel";
 export type { Message } from "./thread/useThreadMessages";

--- a/src/stores/theme/useAccentColor.ts
+++ b/src/stores/theme/useAccentColor.ts
@@ -4,22 +4,22 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { ColorScheme } from "@/theme/types";
 
-interface ThemeColorState {
+interface AccentColorState {
   colorScheme: ColorScheme;
   setColorScheme: (scheme: ColorScheme) => void;
 }
 
-const useTheme = create<ThemeColorState>()(
+const useAccentColor = create<AccentColorState>()(
   persist(
     (set) => ({
       colorScheme: "blue",
       setColorScheme: (scheme) => set({ colorScheme: scheme }),
     }),
     {
-      name: "theme",
+      name: "accent-color",
       storage: createJSONStorage(() => localStorage),
     }
   )
 );
 
-export default useTheme;
+export default useAccentColor;


### PR DESCRIPTION
## Summary
- rename `useTheme` store to `useAccentColor`
- update all components and store exports to use the new accent color hook

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1b9a76f288327a1768e453edef5a7