### PR TITLE
refactor: rename colorScheme to accentColor

### DIFF
--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -61,7 +61,7 @@ const MessageItem: FC<MessageItemProps> = ({
       locale: enUS,
     });
 
-    const { colorScheme } = useAccentColor();
+    const { accentColor } = useAccentColor();
   const { colorMode } = useColorMode();
   const { showToast } = useToastStore();
   const [copied, setCopied] = useState(false);
@@ -127,7 +127,7 @@ const MessageItem: FC<MessageItemProps> = ({
               p={3}
               borderRadius="lg"
               color={isUser ? "white" : ""}
-              bg={isUser ? `${colorScheme}.400` : "mutedSurface"}
+              bg={isUser ? `${accentColor}.400` : "mutedSurface"}
               maxW="max-content"
               whiteSpace="pre-wrap"
               wordBreak="break-word"

--- a/src/components/Settings/Appearance.tsx
+++ b/src/components/Settings/Appearance.tsx
@@ -15,7 +15,7 @@ import {
 
 const Appearance: FC = () => {
   const { setColorMode } = useColorMode();
-  const { colorScheme } = useAccentColor();
+  const { accentColor } = useAccentColor();
   const { user } = useAuth();
 
   const [mode, setMode] = useState<"light" | "dark" | "system">(() => {
@@ -107,12 +107,12 @@ const Appearance: FC = () => {
               key={item.value}
               onClick={() => handleColorModeChange(item.value)}
               variant="outline"
-              colorScheme={isSelected ? colorScheme : "gray"}
-              borderColor={isSelected ? `${colorScheme}.500` : "gray.300"}
-              bg={isSelected ? `${colorScheme}.50` : "transparent"}
+              colorScheme={isSelected ? accentColor : "gray"}
+              borderColor={isSelected ? `${accentColor}.500` : "gray.300"}
+              bg={isSelected ? `${accentColor}.50` : "transparent"}
               _dark={{
-                borderColor: isSelected ? `${colorScheme}.300` : "gray.600",
-                bg: isSelected ? `${colorScheme}.900` : "transparent",
+                borderColor: isSelected ? `${accentColor}.300` : "gray.600",
+                bg: isSelected ? `${accentColor}.900` : "transparent",
               }}
               leftIcon={
                 <Icon

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -35,7 +35,7 @@ interface SettingsProps {
 
 const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
   const { colorMode } = useColorMode();
-  const { colorScheme } = useAccentColor();
+  const { accentColor } = useAccentColor();
   const [tabIndex, setTabIndex] = useState(0);
   const tabListRef = useRef<HTMLDivElement>(null);
   const isMobile = useBreakpointValue({ base: true, md: false }) ?? false;
@@ -163,8 +163,8 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
                   _selected={{
                     color:
                       colorMode === "dark"
-                        ? `${colorScheme}.200`
-                        : `${colorScheme}.600`,
+                        ? `${accentColor}.200`
+                        : `${accentColor}.600`,
                     bgColor: getBg("selected"),
                   }}
                   _hover={{ bgColor: getBg("hover") }}

--- a/src/components/ThreadItem/index.tsx
+++ b/src/components/ThreadItem/index.tsx
@@ -61,7 +61,7 @@ const ThreadItem: FC<ThreadItemProps> = ({
 }) => {
   const { colorMode } = useColorMode();
   const { user } = useAuth();
-  const { colorScheme } = useAccentColor();
+  const { accentColor } = useAccentColor();
   const { showToast } = useToastStore();
   const router = useRouter();
   const pathname = usePathname();
@@ -273,8 +273,8 @@ const ThreadItem: FC<ThreadItemProps> = ({
         color={
           !isSearchActive && isActive
             ? colorMode === "dark"
-              ? `${colorScheme}.300`
-              : `${colorScheme}.500`
+              ? `${accentColor}.300`
+              : `${accentColor}.500`
             : "inherit"
         }
         colorScheme="gray"

--- a/src/components/ThreadList/index.tsx
+++ b/src/components/ThreadList/index.tsx
@@ -58,7 +58,7 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm }) => {
   const [readyToRender, setReadyToRender] = useState(false);
   const [hasScrolledOnce, setHasScrolledOnce] = useState(false);
 
-  const { colorScheme } = useAccentColor();
+  const { accentColor } = useAccentColor();
 
   const fetchMessages = useCallback(
     async (threadId: string): Promise<Message[]> => {
@@ -254,7 +254,7 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm }) => {
                   textAlign="left"
                 >
                   {msg.text.substring(0, start)}
-                  <Box as="span" bgColor={`${colorScheme}.400`} color="gray.50">
+                  <Box as="span" bgColor={`${accentColor}.400`} color="gray.50">
                     {msg.text.substring(start, end)}
                   </Box>
                   {msg.text.substring(end)}
@@ -281,7 +281,7 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm }) => {
     }
 
     return { titleResults: titles, messageResults: messages };
-  }, [searchTerm, loadedThreads, colorScheme]);
+  }, [searchTerm, loadedThreads, accentColor]);
 
   const hasResults = titleResults.length > 0 || messageResults.length > 0;
 

--- a/src/components/ui/Button/index.tsx
+++ b/src/components/ui/Button/index.tsx
@@ -5,8 +5,8 @@ import { Button as ChakraButton, ButtonProps } from "@chakra-ui/react";
 import { useAccentColor } from "@/stores";
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
-  const { colorScheme } = useAccentColor();
-  return <ChakraButton ref={ref} colorScheme={colorScheme} {...props} />;
+  const { accentColor } = useAccentColor();
+  return <ChakraButton ref={ref} colorScheme={accentColor} {...props} />;
 });
 
 Button.displayName = "Button";

--- a/src/components/ui/Input/index.tsx
+++ b/src/components/ui/Input/index.tsx
@@ -21,12 +21,12 @@ const Input: FC<CustomInputProps> = ({
   focusBorderColor,
   ...rest
 }) => {
-  const { colorScheme } = useAccentColor();
+  const { accentColor } = useAccentColor();
   const { colorMode } = useColorMode();
 
   const computedFocusBorderColor =
     focusBorderColor ??
-    (colorMode === "dark" ? `${colorScheme}.300` : `${colorScheme}.400`);
+    (colorMode === "dark" ? `${accentColor}.300` : `${accentColor}.400`);
 
   return (
     <ChakraInput

--- a/src/components/ui/InputGroup/index.tsx
+++ b/src/components/ui/InputGroup/index.tsx
@@ -5,8 +5,8 @@ import { InputGroup as ChakraInputGroup, type InputGroupProps } from "@chakra-ui
 import { useAccentColor } from "@/stores";
 
 const InputGroup = forwardRef<HTMLDivElement, InputGroupProps>((props, ref) => {
-  const { colorScheme } = useAccentColor();
-  return <ChakraInputGroup ref={ref} colorScheme={colorScheme} {...props} />;
+  const { accentColor } = useAccentColor();
+  return <ChakraInputGroup ref={ref} colorScheme={accentColor} {...props} />;
 });
 
 InputGroup.displayName = "InputGroup";

--- a/src/components/ui/Progress/index.tsx
+++ b/src/components/ui/Progress/index.tsx
@@ -5,9 +5,9 @@ import { Progress as ChakraProgress, ProgressProps } from "@chakra-ui/react";
 import { useAccentColor } from "@/stores";
 
 const Progress: FC<ProgressProps> = (props) => {
-  const { colorScheme } = useAccentColor();
+  const { accentColor } = useAccentColor();
 
-  return <ChakraProgress colorScheme={colorScheme} {...props} />;
+  return <ChakraProgress colorScheme={accentColor} {...props} />;
 };
 
 export default Progress;

--- a/src/components/ui/Spinner/index.tsx
+++ b/src/components/ui/Spinner/index.tsx
@@ -9,11 +9,11 @@ import {
 import { useAccentColor } from "@/stores";
 
 const Spinner: FC<SpinnerProps> = (props) => {
-  const { colorScheme } = useAccentColor();
+  const { accentColor } = useAccentColor();
   const { colorMode } = useColorMode();
 
   const color =
-    colorMode === "dark" ? `${colorScheme}.300` : `${colorScheme}.400`;
+    colorMode === "dark" ? `${accentColor}.300` : `${accentColor}.400`;
 
   return <ChakraSpinner color={color} {...props} />;
 };

--- a/src/layouts/Thread/layout.tsx
+++ b/src/layouts/Thread/layout.tsx
@@ -10,9 +10,9 @@ interface ThreadLayoutProps {
 
 const DropOverlay: FC = () => {
   const { colorMode } = useColorMode();
-  const { colorScheme } = useAccentColor();
+  const { accentColor } = useAccentColor();
   const borderColor =
-    colorMode === "dark" ? `${colorScheme}.300` : `${colorScheme}.500`;
+    colorMode === "dark" ? `${accentColor}.300` : `${accentColor}.500`;
 
   return (
     <Flex

--- a/src/stores/theme/useAccentColor.ts
+++ b/src/stores/theme/useAccentColor.ts
@@ -5,15 +5,15 @@ import { persist, createJSONStorage } from "zustand/middleware";
 import { ColorScheme } from "@/theme/types";
 
 interface AccentColorState {
-  colorScheme: ColorScheme;
-  setColorScheme: (scheme: ColorScheme) => void;
+  accentColor: ColorScheme;
+  setAccentColor: (scheme: ColorScheme) => void;
 }
 
 const useAccentColor = create<AccentColorState>()(
   persist(
     (set) => ({
-      colorScheme: "blue",
-      setColorScheme: (scheme) => set({ colorScheme: scheme }),
+      accentColor: "blue",
+      setAccentColor: (scheme) => set({ accentColor: scheme }),
     }),
     {
       name: "accent-color",


### PR DESCRIPTION
## Summary
- rename color scheme store fields to accentColor and setAccentColor
- update components to consume accentColor
- export COLOR_SCHEMES and ColorScheme type in theme types

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a1bbd64d108327be7d794e8ccb8d12