### PR TITLE
Persist image previews per thread

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -41,6 +41,10 @@ const NotFound = () => {
         isDisabled={true}
         input=""
         setInput={noop}
+        preview={null}
+        setPreview={noop}
+        file={null}
+        setFile={noop}
         isListening={false}
         resetTranscript={noop}
         isFetchingResponse={false}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,7 +34,8 @@ const Home: FC = () => {
   const pathname = usePathname();
   const { user } = useAuth();
   const { isMessageTemporary } = useTempThread();
-  const { getInput, setInput } = useThreadInput();
+  const { getInput, setInput, getPreview, setPreview, getFile, setFile } =
+    useThreadInput();
   const { setMessages: setGlobalMessages, addMessageToBottom } =
     useThreadMessages();
   const { model } = useModel();
@@ -47,6 +48,8 @@ const Home: FC = () => {
   const [isListening, setIsListening] = useState(false);
 
   const input = getInput("home");
+  const preview = getPreview("home");
+  const file = getFile("home");
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const prevTranscriptRef = useRef("");
   const hasMounted = useRef(false);
@@ -422,6 +425,10 @@ const Home: FC = () => {
         ref={messageInputRef}
         input={input}
         setInput={(val) => setInput("home", val)}
+        preview={preview}
+        setPreview={(val) => setPreview("home", val)}
+        file={file}
+        setFile={(val) => setFile("home", val)}
         isListening={isListening}
         resetTranscript={resetTranscript}
         isFetchingResponse={isFetchingResponse}

--- a/src/app/thread/[threadId]/page.tsx
+++ b/src/app/thread/[threadId]/page.tsx
@@ -22,8 +22,11 @@ const Thread: FC = () => {
   const router = useRouter();
 
   const { user, loading } = useAuth();
-  const { getInput, setInput } = useThreadInput();
+  const { getInput, setInput, getPreview, setPreview, getFile, setFile } =
+    useThreadInput();
   const input = getInput(threadId || "home");
+  const preview = getPreview(threadId || "home");
+  const file = getFile(threadId || "home");
   const { model } = useModel();
 
   const {
@@ -421,6 +424,10 @@ const Thread: FC = () => {
         ref={messageInputRef}
         input={input}
         setInput={(val) => setInput(threadId || "home", val)}
+        preview={preview}
+        setPreview={(val) => setPreview(threadId || "home", val)}
+        file={file}
+        setFile={(val) => setFile(threadId || "home", val)}
         isListening={isListening}
         resetTranscript={resetTranscript}
         isFetchingResponse={isFetchingResponse}

--- a/src/app/thread/temp/page.tsx
+++ b/src/app/thread/temp/page.tsx
@@ -33,8 +33,11 @@ const TempThread: FC = () => {
   const [isListening, setIsListening] = useState(false);
   const [playingMessage, setPlayingMessage] = useState<string | null>(null);
 
-  const { getInput, setInput } = useThreadInput();
+  const { getInput, setInput, getPreview, setPreview, getFile, setFile } =
+    useThreadInput();
   const input = getInput("home");
+  const preview = getPreview("home");
+  const file = getFile("home");
   const { model } = useModel();
 
   const { transcript, listening, resetTranscript } = useSpeechRecognition();
@@ -263,6 +266,10 @@ const TempThread: FC = () => {
         ref={messageInputRef}
         input={isBlocked ? "" : input}
         setInput={(val) => setInput("home", val)}
+        preview={isBlocked ? null : preview}
+        setPreview={(val) => setPreview("home", val)}
+        file={isBlocked ? null : file}
+        setFile={(val) => setFile("home", val)}
         isListening={isBlocked ? false : isListening}
         resetTranscript={resetTranscript}
         isFetchingResponse={isFetchingResponse}

--- a/src/components/MessageInput/index.tsx
+++ b/src/components/MessageInput/index.tsx
@@ -32,6 +32,10 @@ export interface MessageInputHandle {
 interface MessageInputProps {
   input: string;
   setInput: (value: string) => void;
+  preview: string | null;
+  setPreview: (value: string | null) => void;
+  file: File | null;
+  setFile: (file: File | null) => void;
   isListening: boolean;
   resetTranscript: () => void;
   isFetchingResponse: boolean;
@@ -46,6 +50,10 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     {
       input,
       setInput,
+      preview,
+      setPreview,
+      file,
+      setFile,
       isListening,
       resetTranscript,
       isFetchingResponse,
@@ -62,7 +70,6 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
 
     const { accentColor } = useAccentColor();
 
-    const [preview, setPreview] = useState<string | null>(null);
     const [isPreviewOpen, setIsPreviewOpen] = useState(false);
 
     const handleFile = (file: File) => {
@@ -76,6 +83,7 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       }
       const url = URL.createObjectURL(file);
       setPreview(url);
+      setFile(file);
     };
 
     const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -87,17 +95,20 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
     const handleDiscard = () => {
       if (preview) URL.revokeObjectURL(preview);
       setPreview(null);
+      setFile(null);
       discardImage();
       setIsPreviewOpen(false);
     };
 
     useEffect(() => {
-      return () => {
-        if (preview) {
-          URL.revokeObjectURL(preview);
-        }
-      };
-    }, [preview]);
+      if (file && fileInputRef.current) {
+        const dt = new DataTransfer();
+        dt.items.add(file);
+        fileInputRef.current.files = dt.files;
+      } else if (!file && fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }, [file, fileInputRef]);
 
     useImperativeHandle(ref, () => ({ handleFile }));
 
@@ -106,6 +117,7 @@ const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(
       if (preview) {
         URL.revokeObjectURL(preview);
         setPreview(null);
+        setFile(null);
         setIsPreviewOpen(false);
       }
       await sendPromise;

--- a/src/stores/thread/useThreadInput.ts
+++ b/src/stores/thread/useThreadInput.ts
@@ -2,16 +2,24 @@ import { create } from "zustand";
 
 interface InputStore {
   inputsByThread: Record<string, string>;
+  previewsByThread: Record<string, string | null>;
+  filesByThread: Record<string, File | null>;
   setInput: (
     threadId: string,
     input: string | ((prev: string) => string)
   ) => void;
   getInput: (threadId: string) => string;
+  setPreview: (threadId: string, preview: string | null) => void;
+  getPreview: (threadId: string) => string | null;
+  setFile: (threadId: string, file: File | null) => void;
+  getFile: (threadId: string) => File | null;
   clearInputs: () => void;
 }
 
 const useThreadInput = create<InputStore>((set, get) => ({
   inputsByThread: {},
+  previewsByThread: {},
+  filesByThread: {},
   setInput: (threadId, input) => {
     set((state) => ({
       inputsByThread: {
@@ -24,7 +32,29 @@ const useThreadInput = create<InputStore>((set, get) => ({
     }));
   },
   getInput: (threadId) => get().inputsByThread[threadId] ?? "",
-  clearInputs: () => set({ inputsByThread: {} }),
+  setPreview: (threadId, preview) => {
+    set((state) => ({
+      previewsByThread: {
+        ...state.previewsByThread,
+        [threadId]: preview,
+      },
+    }));
+  },
+  getPreview: (threadId) => get().previewsByThread[threadId] ?? null,
+  setFile: (threadId, file) => {
+    set((state) => ({
+      filesByThread: {
+        ...state.filesByThread,
+        [threadId]: file,
+      },
+    }));
+  },
+  getFile: (threadId) => get().filesByThread[threadId] ?? null,
+  clearInputs: () => set({
+    inputsByThread: {},
+    previewsByThread: {},
+    filesByThread: {},
+  }),
 }));
 
 export default useThreadInput;


### PR DESCRIPTION
## Summary
- store message input text, image preview URLs, and selected files per thread
- keep image previews and file selection when navigating between pages
- update message input to manage external preview state and cleanup

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a53504912c83278fb32e30fdada3a9