### PR TITLE
fix: show thread loading indicator only after user scrolls

### DIFF
--- a/src/components/ThreadList/index.tsx
+++ b/src/components/ThreadList/index.tsx
@@ -52,6 +52,7 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm, onThreadClick })
   const isSearchActive = !!searchTerm;
 
   const virtuosoRef = useRef<VirtuosoHandle>(null);
+  const scrollerRef = useRef<HTMLDivElement>(null);
   const [loadedThreads, setLoadedThreads] = useState<Thread[]>([]);
   const [lastIndex, setLastIndex] = useState<number>(0);
   const [isLoadingMoreThreads, setIsLoadingMoreThreads] = useState(false);
@@ -90,7 +91,7 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm, onThreadClick })
 
   useEffect(() => {
     if (
-      hasScrolledOnce ||
+      readyToRender ||
       isSearchActive ||
       !pathname ||
       loadedThreads.length === 0
@@ -111,15 +112,30 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm, onThreadClick })
 
           setTimeout(() => {
             setReadyToRender(true);
-            setHasScrolledOnce(true);
           }, 100);
         });
       });
     } else {
       setReadyToRender(true);
-      setHasScrolledOnce(true);
     }
-  }, [pathname, loadedThreads, isSearchActive, hasScrolledOnce]);
+  }, [pathname, loadedThreads, isSearchActive, readyToRender]);
+
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+
+    const handleScroll = () => {
+      if (!hasScrolledOnce) {
+        setHasScrolledOnce(true);
+      }
+    };
+
+    scroller.addEventListener("scroll", handleScroll);
+
+    return () => {
+      scroller.removeEventListener("scroll", handleScroll);
+    };
+  }, [hasScrolledOnce]);
 
   const loadMoreThreads = useCallback(async () => {
     if (!user || isSearchActive || isLoadingMoreThreads || !hasMoreThreads)
@@ -383,6 +399,7 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm, onThreadClick })
           >
             <Virtuoso
               ref={virtuosoRef}
+              scrollerRef={scrollerRef}
               style={{ height: "100%" }}
               data={allItems}
               initialTopMostItemIndex={0}


### PR DESCRIPTION
## Summary
- track user scrolling in thread list before allowing lazy-loading
- prevent thread loading indicator from showing during initial render

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a88ed233ac832781bdf538b1381618