### PR TITLE
Prevent duplicate chat messages

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -133,7 +133,9 @@ const Home: FC = () => {
       const botResponse =
         data?.candidates?.[0]?.content?.parts?.[0]?.text || "No response";
 
+      const botMessageId = uuidv4();
       const botMessage: Message = {
+        id: botMessageId,
         text: botResponse,
         sender: "bot",
         timestamp: Date.now(),
@@ -146,6 +148,7 @@ const Home: FC = () => {
         addMessageToBottom(threadId, botMessage);
 
         await supabase.from("messages").insert({
+          id: botMessageId,
           user_id: user.id,
           thread_id: threadId,
           text: botMessage.text,
@@ -297,6 +300,7 @@ const Home: FC = () => {
     const now = new Date().toISOString();
     const timestamp = Date.now();
     const fileId = uuidv4();
+    const messageId = uuidv4();
 
     const id = threadId || (user && !isMessageTemporary ? uuidv4() : null);
     const isNewThread = !!user && !threadId && !isMessageTemporary && !!id;
@@ -348,6 +352,7 @@ const Home: FC = () => {
 
     const textToSend = input.trim() || null;
     const userMessage: Message = {
+      id: messageId,
       text: textToSend,
       sender: "user",
       timestamp,
@@ -368,6 +373,7 @@ const Home: FC = () => {
         }
 
         await supabase.from("messages").insert({
+          id: messageId,
           user_id: user.id,
           thread_id: id,
           text: userMessage.text,

--- a/src/app/thread/[threadId]/page.tsx
+++ b/src/app/thread/[threadId]/page.tsx
@@ -198,7 +198,9 @@ const Thread: FC = () => {
       const botText =
         data?.candidates?.[0]?.content?.parts?.[0]?.text || "No response";
 
+      const botMessageId = uuidv4();
       const botMessage: Message = {
+        id: botMessageId,
         text: botText,
         sender: "bot",
         timestamp: Date.now(),
@@ -209,6 +211,7 @@ const Thread: FC = () => {
 
       try {
         await supabase.from("messages").insert({
+          id: botMessageId,
           user_id: user.id,
           thread_id: threadId,
           text: botMessage.text,
@@ -328,6 +331,7 @@ const Thread: FC = () => {
     const now = new Date().toISOString();
     const timestamp = Date.now();
     const fileId = uuidv4();
+    const messageId = uuidv4();
 
     let imageData: Message["image"] | undefined;
     if (base64Image) {
@@ -362,6 +366,7 @@ const Thread: FC = () => {
     }
 
     const userMessage: Message = {
+      id: messageId,
       text: input.trim() || null,
       sender: "user",
       timestamp,
@@ -375,6 +380,7 @@ const Thread: FC = () => {
 
     try {
       await supabase.from("messages").insert({
+        id: messageId,
         user_id: user.id,
         thread_id: threadId,
         text: userMessage.text,

--- a/src/stores/thread/useThreadMessages.ts
+++ b/src/stores/thread/useThreadMessages.ts
@@ -67,14 +67,13 @@ const useThreadMessages = create<ThreadMessageStore>()(
         set((state) => {
           const existing = state.messagesByThread[threadId] || [];
 
-          const isDuplicate = message.id
-            ? existing.some((msg) => msg.id === message.id)
-            : existing.some(
-                (msg) =>
-                  msg.timestamp === message.timestamp &&
-                  msg.sender === message.sender &&
-                  msg.text === message.text
-              );
+          const isDuplicate = existing.some(
+            (msg) =>
+              (message.id && msg.id === message.id) ||
+              (msg.timestamp === message.timestamp &&
+                msg.sender === message.sender &&
+                msg.text === message.text)
+          );
 
           if (isDuplicate) return state;
 


### PR DESCRIPTION
## Summary
- Deduplicate messages in thread store by checking IDs and timestamps
- Generate explicit UUIDs for user and bot messages before inserting into the database
- Persist generated IDs to Supabase to avoid duplicate entries and state updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad1632294c8327a0c00df403bd59b6