### PR TITLE
fix: improve mobile height and bottom scrolling

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,7 @@ const RootLayout = ({ children }: { children: ReactNode }) => {
       <body>
         <Providers>
           <AuthInitializer>
-            <Flex h="100vh" overflow="hidden">
+            <Flex h="100dvh" overflow="hidden">
               <SideBar type="persistent" />
               <Flex direction="column" flex="1">
                 <NavigationBar />

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -118,7 +118,7 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
       isCentered
     >
       <ModalOverlay />
-      <ModalContent h={{ base: "100vh", md: "auto" }}>
+      <ModalContent h={{ base: "100dvh", md: "auto" }}>
         <ModalHeader>Settings</ModalHeader>
         <ModalCloseButton />
         <Divider orientation="horizontal" />

--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -357,8 +357,8 @@ const SideBar: FC<SideBarProps> = ({ type, isOpen, placement, onClose }) => {
   };
 
   const content = (
-    <Box display={!isLargeScreen ? "none" : "flex"} height="100vh">
-      <Card borderRadius={0} h="100vh" w={`${sidebarWidth}px`}>
+    <Box display={!isLargeScreen ? "none" : "flex"} height="100dvh">
+      <Card borderRadius={0} h="100dvh" w={`${sidebarWidth}px`}>
         <Flex direction="column" h="100%">
           <Flex
             px={3}
@@ -451,7 +451,7 @@ const SideBar: FC<SideBarProps> = ({ type, isOpen, placement, onClose }) => {
         >
           <DrawerOverlay />
           <DrawerContent>
-            <Card borderRadius={0} h="100vh">
+            <Card borderRadius={0} h="100dvh">
               <DrawerHeader
                 px={3}
                 py={2}

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -186,14 +186,15 @@ const MessagesLayout: FC<MessagesLayoutProps> = ({
           </Flex>
         </VStack>
       ) : (
-        <Box
-          h="100%"
-          overflow={readyToRender ? "auto" : "hidden"}
-          visibility={readyToRender ? "visible" : "hidden"}
-        >
+        <Box h="100%" overflow="hidden">
           <Virtuoso
             ref={virtuosoRef}
-            style={{ height: "100%", minHeight: 100 }}
+            style={{
+              height: "100%",
+              minHeight: 100,
+              overflowY: readyToRender ? "auto" : "hidden",
+              visibility: readyToRender ? "visible" : "hidden",
+            }}
             data={virtualMessages}
             followOutput="auto"
             increaseViewportBy={200}


### PR DESCRIPTION
## Summary
- prevent nested scrolling in message list for stable bottom detection
- use dynamic viewport height (`100dvh`) for layout, sidebar, and settings modal to improve mobile rendering

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad461d680483278fa7e6528eb9debf