### PR TITLE
Improve thread search performance and message navigation

### DIFF
--- a/src/app/thread/[threadId]/page.tsx
+++ b/src/app/thread/[threadId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FC, useEffect, useRef, useState } from "react";
-import { notFound, useParams, useRouter } from "next/navigation";
+import { notFound, useParams, useRouter, useSearchParams } from "next/navigation";
 import { useSpeechRecognition } from "react-speech-recognition";
 import { v4 as uuidv4 } from "uuid";
 
@@ -20,6 +20,8 @@ import {
 const Thread: FC = () => {
   const { threadId } = useParams<{ threadId: string }>();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const scrollToMessageId = searchParams.get("messageId");
 
   const { user, loading } = useAuth();
   const { getInput, setInput, getPreview, setPreview, getFile, setFile } =
@@ -425,6 +427,7 @@ const Thread: FC = () => {
         onLoadMore={handleLoadMessages}
         isLoading={loadingMessages}
         onRetryMessage={retryBotMessage}
+        scrollToMessageId={scrollToMessageId}
       />
       <MessageInput
         ref={messageInputRef}

--- a/src/components/ThreadItem/index.tsx
+++ b/src/components/ThreadItem/index.tsx
@@ -43,11 +43,12 @@ interface Thread {
 interface ThreadItemProps extends Omit<ButtonProps, "onClick"> {
   thread: Thread;
   isActive: boolean;
-  onThreadClick: (id: string) => void;
+  onThreadClick: (id: string, messageId?: string) => void;
   onDeleteThread?: (id: string) => void;
   isMessageMatch?: boolean;
   highlightedText?: ReactNode;
   isSearchActive: boolean;
+  messageId?: string;
 }
 
 const ThreadItem: FC<ThreadItemProps> = ({
@@ -58,6 +59,7 @@ const ThreadItem: FC<ThreadItemProps> = ({
   isMessageMatch = false,
   highlightedText,
   isSearchActive,
+  messageId,
 }) => {
   const { colorMode } = useColorMode();
   const { user } = useAuth();
@@ -273,7 +275,7 @@ const ThreadItem: FC<ThreadItemProps> = ({
         flex="1"
         minW={0}
         justifyContent="flex-start"
-        onClick={() => onThreadClick(thread.id)}
+        onClick={() => onThreadClick(thread.id, messageId)}
         textAlign="left"
         py={isMessageMatch ? 6 : 0}
         color={

--- a/src/components/ThreadList/index.tsx
+++ b/src/components/ThreadList/index.tsx
@@ -10,6 +10,7 @@ import {
   useCallback,
   useEffect,
   useRef,
+  useDeferredValue,
 } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
@@ -31,7 +32,7 @@ interface SearchResultItem {
 interface ThreadListProps {
   threads: Thread[];
   searchTerm: string;
-  onThreadClick?: (id: string) => void;
+  onThreadClick?: (id: string, messageId?: string) => void;
 }
 
 type VirtuosoItem =
@@ -42,6 +43,7 @@ type VirtuosoItem =
         thread: Thread;
         isMessageMatch: boolean;
         highlightedText?: ReactNode;
+        messageId?: string;
       };
     };
 
@@ -49,7 +51,8 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm, onThreadClick })
   const { user } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
-  const isSearchActive = !!searchTerm;
+  const deferredSearchTerm = useDeferredValue(searchTerm);
+  const isSearchActive = !!deferredSearchTerm;
 
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const [loadedThreads, setLoadedThreads] = useState<Thread[]>([]);
@@ -223,20 +226,20 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm, onThreadClick })
   }, [user, fetchMessages]);
 
   const { titleResults, messageResults } = useMemo(() => {
-    const lower = searchTerm.toLowerCase();
+    const lower = deferredSearchTerm.toLowerCase();
 
     const titles = loadedThreads
-      .filter((t) => !searchTerm || t.title?.toLowerCase().includes(lower))
+      .filter((t) => !deferredSearchTerm || t.title?.toLowerCase().includes(lower))
       .sort((a, b) => (a.title || "").localeCompare(b.title || ""));
 
     const messages: SearchResultItem[] = [];
 
-    if (searchTerm) {
+    if (deferredSearchTerm) {
       loadedThreads.forEach((thread) => {
         thread.messages?.forEach((msg) => {
           if (msg.text && msg.text.toLowerCase().includes(lower)) {
             const start = msg.text.toLowerCase().indexOf(lower);
-            const end = start + searchTerm.length;
+            const end = start + deferredSearchTerm.length;
 
             const createdAt = msg.created_at
               ? new Date(msg.created_at).getTime() / 1000
@@ -287,7 +290,7 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm, onThreadClick })
     }
 
     return { titleResults: titles, messageResults: messages };
-  }, [searchTerm, loadedThreads, bgHighlight, textHighlight]);
+  }, [deferredSearchTerm, loadedThreads, bgHighlight, textHighlight]);
 
   const hasResults = titleResults.length > 0 || messageResults.length > 0;
 
@@ -318,6 +321,7 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm, onThreadClick })
               thread: result.thread,
               isMessageMatch: true,
               highlightedText: result.highlightedText,
+              messageId: result.message?.id,
             },
           })
         );
@@ -334,11 +338,14 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm, onThreadClick })
       }));
   }, [isSearchActive, hasResults, titleResults, messageResults, loadedThreads]);
 
-  const handleThreadClick = (threadId: string) => {
+  const handleThreadClick = (threadId: string, messageId?: string) => {
     if (onThreadClick) {
-      onThreadClick(threadId);
+      onThreadClick(threadId, messageId);
     } else {
-      router.push(`/thread/${threadId}`);
+      const url = messageId
+        ? `/thread/${threadId}?messageId=${messageId}`
+        : `/thread/${threadId}`;
+      router.push(url);
     }
   };
 
@@ -413,13 +420,15 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm, onThreadClick })
                   );
                 }
 
-                const { thread, isMessageMatch, highlightedText } = item.data;
+                const { thread, isMessageMatch, highlightedText, messageId } =
+                  item.data;
                 return (
                   <Box mx={3} pt={isFirst ? 3 : 0} pb={isLast ? 3 : 0}>
                     <ThreadItem
                       thread={thread}
                       isActive={pathname === `/thread/${thread.id}`}
                       onThreadClick={handleThreadClick}
+                      messageId={messageId}
                       isMessageMatch={isMessageMatch}
                       highlightedText={highlightedText}
                       isSearchActive={isSearchActive}

--- a/src/layouts/Messages/layout.tsx
+++ b/src/layouts/Messages/layout.tsx
@@ -57,6 +57,7 @@ interface MessagesLayoutProps {
   emptyStateText?: string;
   onLoadMore?: () => Promise<void>;
   onRetryMessage?: (message: Message) => void;
+  scrollToMessageId?: string | null;
 }
 
 const MessagesLayout: FC<MessagesLayoutProps> = ({
@@ -71,6 +72,7 @@ const MessagesLayout: FC<MessagesLayoutProps> = ({
   emptyStateText = "Hello, what can I help with?",
   onLoadMore,
   onRetryMessage,
+  scrollToMessageId,
 }) => {
   const { user: authUser } = useAuth();
   const { accentColor } = useAccentColor();
@@ -123,6 +125,22 @@ const MessagesLayout: FC<MessagesLayoutProps> = ({
       });
     }
   }, [virtualMessages.length, readyToRender]);
+
+  useEffect(() => {
+    if (!scrollToMessageId || !readyToRender) return;
+    const index = virtualMessages.findIndex(
+      (item) =>
+        item.type === "message" &&
+        (item.value as Message).id === scrollToMessageId
+    );
+    if (index >= 0) {
+      virtuosoRef.current?.scrollToIndex({
+        index,
+        align: "start",
+        behavior: "smooth",
+      });
+    }
+  }, [scrollToMessageId, readyToRender, virtualMessages]);
 
   const scrollToBottom = useCallback(() => {
     virtuosoRef.current?.scrollToIndex({


### PR DESCRIPTION
## Summary
- use React's `useDeferredValue` to defer search term filtering for smoother thread list performance
- allow message search results to navigate directly to the matching message and scroll to it
- wire MessagesLayout and thread page to accept a message ID anchor for automatic scrolling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68ad51a958308327b516aa34adf60f49