### PR TITLE
Ensure thread search updates after new messages

### DIFF
--- a/src/components/SideBar/index.tsx
+++ b/src/components/SideBar/index.tsx
@@ -279,9 +279,12 @@ const SideBar: FC<SideBarProps> = ({ type, isOpen, placement, onClose }) => {
           }
 
           if (payload.eventType === "UPDATE") {
+            const messages = await fetchMessages(updatedThread.id);
             setThreads((prev) =>
               prev.map((t) =>
-                t.id === updatedThread.id ? { ...t, ...updatedThread } : t
+                t.id === updatedThread.id
+                  ? { ...t, ...updatedThread, messages }
+                  : t
               )
             );
           }

--- a/src/components/ThreadList/index.tsx
+++ b/src/components/ThreadList/index.tsx
@@ -205,10 +205,13 @@ const ThreadList: FC<ThreadListProps> = ({ threads, searchTerm, onThreadClick })
               ])
             );
           } else if (payload.eventType === "UPDATE") {
+            const messages = await fetchMessages(newThread.id);
             setLoadedThreads((prev) =>
               sortThreads(
                 prev.map((t) =>
-                  t.id === newThread.id ? { ...t, ...newThread } : t
+                  t.id === newThread.id
+                    ? { ...t, ...newThread, messages }
+                    : t
                 )
               )
             );


### PR DESCRIPTION
## Summary
- Fetch latest messages when threads update so search results include new messages immediately

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae6f983fec832782ad9fe786b59583