### PR TITLE
Add general settings for follow-up suggestions

### DIFF
--- a/src/components/Settings/General.tsx
+++ b/src/components/Settings/General.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { FC } from "react";
+import {
+  Box,
+  Flex,
+  FormControl,
+  FormLabel,
+  Switch,
+  Text,
+} from "@chakra-ui/react";
+import { useChatSettings } from "@/stores";
+
+const SectionTitle = ({ title, desc }: { title: string; desc: string }) => (
+  <Flex direction="column" gap={1} mb={2}>
+    <Text fontWeight="semibold" fontSize="md">
+      {title}
+    </Text>
+    <Text fontSize="sm" color="secondaryText">
+      {desc}
+    </Text>
+  </Flex>
+);
+
+const General: FC = () => {
+  const { showFollowUpSuggestions, toggleFollowUpSuggestions } =
+    useChatSettings();
+
+  return (
+    <Flex direction="column" gap={6}>
+      <Box>
+        <SectionTitle
+          title="Follow-up Suggestions"
+          desc="Control whether suggestions appear after responses"
+        />
+        <FormControl display="flex" alignItems="center" gap={3}>
+          <Switch
+            id="follow-up-suggestions"
+            isChecked={showFollowUpSuggestions}
+            onChange={toggleFollowUpSuggestions}
+          />
+          <FormLabel htmlFor="follow-up-suggestions" mb="0">
+            Show Follow-up Suggestions in Chat
+          </FormLabel>
+        </FormControl>
+      </Box>
+    </Flex>
+  );
+};
+
+export default General;

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -27,6 +27,7 @@ import { BiMessageDetail, BiSolidMessageDetail } from "react-icons/bi";
 import { TbArrowBigUpLines, TbArrowBigUpLinesFilled } from "react-icons/tb";
 import { HiLockClosed, HiOutlineLockClosed, HiOutlineUser } from "react-icons/hi";
 import Appearance from "./Appearance";
+import General from "./General";
 
 interface SettingsProps {
   isOpen: boolean;
@@ -189,7 +190,9 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
             />
 
             <TabPanels flex="1" minH={0} overflowY="auto">
-              <TabPanel>General settings go here.</TabPanel>
+              <TabPanel>
+                <General />
+              </TabPanel>
               <TabPanel>
                 <Appearance />
               </TabPanel>

--- a/src/stores/chat/useChatSettings.ts
+++ b/src/stores/chat/useChatSettings.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { create } from "zustand";
+
+interface ChatSettingsState {
+  showFollowUpSuggestions: boolean;
+  toggleFollowUpSuggestions: () => void;
+}
+
+const useChatSettings = create<ChatSettingsState>((set) => ({
+  showFollowUpSuggestions: true,
+  toggleFollowUpSuggestions: () =>
+    set((state) => ({
+      showFollowUpSuggestions: !state.showFollowUpSuggestions,
+    })),
+}));
+
+export default useChatSettings;

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -5,4 +5,5 @@ export { default as useTempThread } from "./thread/useTempThread";
 export { default as useAccentColor } from "./theme/useAccentColor";
 export { default as useToastStore } from "./components/useToastStore";
 export { default as useModel } from "./model/useModel";
+export { default as useChatSettings } from "./chat/useChatSettings";
 export type { Message } from "./thread/useThreadMessages";


### PR DESCRIPTION
## Summary
- add General settings component with 'Show Follow-up Suggestions in Chat' toggle
- create Zustand store for chat settings
- integrate General settings into Settings modal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae9442b59c83279a450a86629688d4