### PR TITLE
Append smart suggestions to bot replies

### DIFF
--- a/src/utils/smartSuggestions.ts
+++ b/src/utils/smartSuggestions.ts
@@ -1,16 +1,31 @@
+/**
+ * Generate follow-up ideas for a conversation.
+ * Returns null if the user's message doesn't appear to ask a question
+ * or if the model decides no suggestion is needed.
+ */
 export const generateSmartSuggestions = async (
   userText: string | null,
   botText: string,
   model: string
 ): Promise<string | null> => {
   if (!userText) return null;
+
+  const trimmed = userText.trim();
+  const questionLikePattern = /\?|\b(who|what|where|when|why|how|which|can|could|would|should|do|does|did|is|are|may|will|shall|have|has|had)\b/i;
+
+  if (!questionLikePattern.test(trimmed)) {
+    return null;
+  }
+
   try {
-    const prompt = `Based on the user's question: "${userText}" and your answer: "${botText}", provide two short follow-up questions or suggestions for the user.`;
+    const prompt = `You are a professional conversational assistant. If the user's message is a greeting, small talk, or does not require further discussion, respond with an empty string. Otherwise, suggest helpful follow-up questions or next steps based on the conversation. Use a single sentence or a short list (bullets or numbers) as appropriate.\n\nUser: ${trimmed}\nAssistant: ${botText}`;
+
     const res = await fetch("/api/gemini", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ message: prompt, model }),
     });
+
     const data = await res.json();
     const suggestions = data?.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
     return suggestions || null;

--- a/src/utils/smartSuggestions.ts
+++ b/src/utils/smartSuggestions.ts
@@ -1,0 +1,21 @@
+export const generateSmartSuggestions = async (
+  userText: string | null,
+  botText: string,
+  model: string
+): Promise<string | null> => {
+  if (!userText) return null;
+  try {
+    const prompt = `Based on the user's question: "${userText}" and your answer: "${botText}", provide two short follow-up questions or suggestions for the user.`;
+    const res = await fetch("/api/gemini", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: prompt, model }),
+    });
+    const data = await res.json();
+    const suggestions = data?.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+    return suggestions || null;
+  } catch (error) {
+    console.error("Failed to generate suggestions:", error);
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- generate follow-up suggestions with a new smartSuggestions utility
- append suggestions to bot messages on home and thread pages when smart suggestions are enabled

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afcefec0d88327b60810198f3b477a