### PR TITLE
fix: ensure bullet lists render consistently

### DIFF
--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -162,9 +162,25 @@ const MessageItem: FC<MessageItemProps> = ({
             >
               <ReactMarkdown
                 components={{
-                  ul: ({ children }) => (
-                    <ul style={{ paddingLeft: "20px" }}>{children}</ul>
+                  ul: (props) => (
+                    <ul
+                      style={{ paddingLeft: "20px", margin: 0 }}
+                      {...props}
+                    />
                   ),
+                  ol: (props) => (
+                    <ol
+                      style={{ paddingLeft: "20px", margin: 0 }}
+                      {...props}
+                    />
+                  ),
+                  li: (props) => (
+                    <li
+                      style={{ margin: 0, listStylePosition: "inside" }}
+                      {...props}
+                    />
+                  ),
+                  p: (props) => <p style={{ margin: 0 }} {...props} />,
                   a: ({ ...props }) => (
                     <a
                       {...props}


### PR DESCRIPTION
## Summary
- ensure markdown lists have consistent spacing and bullet styles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1395101c083279e95db68ae69dda8