### PR TITLE
fix: ensure bullet lists render inside message bubble

### DIFF
--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -18,6 +18,7 @@ import {
   BoxProps,
   useColorMode,
   useColorModeValue,
+  chakra,
 } from "@chakra-ui/react";
 import { ImageModal } from "@themed-components";
 import { useAccentColor, useToastStore } from "@/stores";
@@ -163,7 +164,14 @@ const MessageItem: FC<MessageItemProps> = ({
               <ReactMarkdown
                 components={{
                   ul: ({ children }) => (
-                    <ul style={{ paddingLeft: "20px" }}>{children}</ul>
+                    <chakra.ul pl={4} m={0} listStylePosition="inside">
+                      {children}
+                    </chakra.ul>
+                  ),
+                  ol: ({ children }) => (
+                    <chakra.ol pl={4} m={0} listStylePosition="inside">
+                      {children}
+                    </chakra.ol>
                   ),
                   a: ({ ...props }) => (
                     <a


### PR DESCRIPTION
## Summary
- keep message list bullets inside the bubble using Chakra list components

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: supabaseUrl is required)


------
https://chatgpt.com/codex/tasks/task_e_68b1395101c083279e95db68ae69dda8