### PR TITLE
fix: ensure bullets render inside message items

### DIFF
--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -116,7 +116,6 @@ const MessageItem: FC<MessageItemProps> = ({
     <Flex
       direction="column"
       align={isUser ? "flex-end" : "flex-start"}
-      overflowX="hidden"
       py={1}
       {...props}
     >
@@ -163,7 +162,14 @@ const MessageItem: FC<MessageItemProps> = ({
               <ReactMarkdown
                 components={{
                   ul: ({ children }) => (
-                    <ul style={{ paddingLeft: "20px" }}>{children}</ul>
+                    <ul
+                      style={{
+                        paddingLeft: "20px",
+                        listStylePosition: "inside",
+                      }}
+                    >
+                      {children}
+                    </ul>
                   ),
                   a: ({ ...props }) => (
                     <a


### PR DESCRIPTION
## Summary
- prevent message item from clipping list bullets
- position list bullets inside the bubble for consistent rendering

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1395101c083279e95db68ae69dda8