### PR TITLE
fix: ensure consistent bullet list rendering

### DIFF
--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -18,6 +18,9 @@ import {
   BoxProps,
   useColorMode,
   useColorModeValue,
+  List,
+  ListItem,
+  OrderedList,
 } from "@chakra-ui/react";
 import { ImageModal } from "@themed-components";
 import { useAccentColor, useToastStore } from "@/stores";
@@ -163,30 +166,28 @@ const MessageItem: FC<MessageItemProps> = ({
               <ReactMarkdown
                 components={{
                   ul: ({ children }) => (
-                    <Box
-                      as="ul"
+                    <List
+                      styleType="disc"
+                      stylePosition="outside"
                       pl={4}
                       m={0}
-                      style={{ listStylePosition: "inside" }}
                     >
                       {children}
-                    </Box>
+                    </List>
                   ),
                   ol: ({ children }) => (
-                    <Box
-                      as="ol"
+                    <OrderedList
+                      stylePosition="outside"
                       pl={4}
                       m={0}
-                      style={{ listStylePosition: "inside" }}
                     >
                       {children}
-                    </Box>
+                    </OrderedList>
                   ),
                   li: ({ children }) => (
-                    <Box as="li" mb={1}>
-                      {children}
-                    </Box>
+                    <ListItem mb={1}>{children}</ListItem>
                   ),
+                  p: ({ children }) => <Text m={0}>{children}</Text>,
                   a: ({ ...props }) => (
                     <a
                       {...props}

--- a/src/components/MessageItem/index.tsx
+++ b/src/components/MessageItem/index.tsx
@@ -163,7 +163,29 @@ const MessageItem: FC<MessageItemProps> = ({
               <ReactMarkdown
                 components={{
                   ul: ({ children }) => (
-                    <ul style={{ paddingLeft: "20px" }}>{children}</ul>
+                    <Box
+                      as="ul"
+                      pl={4}
+                      m={0}
+                      style={{ listStylePosition: "inside" }}
+                    >
+                      {children}
+                    </Box>
+                  ),
+                  ol: ({ children }) => (
+                    <Box
+                      as="ol"
+                      pl={4}
+                      m={0}
+                      style={{ listStylePosition: "inside" }}
+                    >
+                      {children}
+                    </Box>
+                  ),
+                  li: ({ children }) => (
+                    <Box as="li" mb={1}>
+                      {children}
+                    </Box>
                   ),
                   a: ({ ...props }) => (
                     <a


### PR DESCRIPTION
## Summary
- render list items using Chakra components to keep bullets and content aligned
- support ordered lists and uniform spacing in markdown messages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b1395101c083279e95db68ae69dda8