### PR TITLE
feat: add accent color select component

### DIFF
--- a/src/components/Settings/VoiceAndAccessibility.tsx
+++ b/src/components/Settings/VoiceAndAccessibility.tsx
@@ -10,8 +10,8 @@ import {
   Flex,
   Grid,
   Text,
-  Select,
 } from "@chakra-ui/react";
+import { Select } from "@/components/ui";
 import { useTTSVoice, useAuth } from "@/stores";
 import { supabase } from "@/lib";
 

--- a/src/components/ui/Select/index.tsx
+++ b/src/components/ui/Select/index.tsx
@@ -1,42 +1,107 @@
 "use client";
 
-import { forwardRef } from "react";
 import {
-  Select as ChakraSelect,
-  type SelectProps,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItemOption,
+  MenuOptionGroup,
+  Button,
+  type ButtonProps,
   useColorMode,
 } from "@chakra-ui/react";
+import { ChevronDownIcon } from "@chakra-ui/icons";
+import {
+  Children,
+  forwardRef,
+  isValidElement,
+  type ReactElement,
+  type ChangeEvent,
+  type ReactNode,
+} from "react";
 import { useAccentColor } from "@/stores";
 
-const Select = forwardRef<HTMLSelectElement, SelectProps>(
-  ({ focusBorderColor, ...props }, ref) => {
+interface SelectProps extends Omit<ButtonProps, "onChange"> {
+  value?: string;
+  onChange?: (e: ChangeEvent<HTMLSelectElement>) => void;
+  placeholder?: ReactNode;
+  children:
+    | ReactElement<React.OptionHTMLAttributes<HTMLOptionElement>>
+    | ReactElement<React.OptionHTMLAttributes<HTMLOptionElement>>[];
+}
+
+const Select = forwardRef<HTMLButtonElement, SelectProps>(
+  ({ value = "", onChange, placeholder, children, ...props }, ref) => {
     const { accentColor } = useAccentColor();
     const { colorMode } = useColorMode();
-    const computedFocusBorderColor =
-      focusBorderColor ??
-      (colorMode === "dark" ? `${accentColor}.300` : `${accentColor}.400`);
-    const optionBg = colorMode === "dark" ? "gray.700" : "white";
-    const optionHighlightBg =
+
+    const options = Children.toArray(children)
+      .filter(isValidElement)
+      .map((child) => {
+        const option =
+          child as ReactElement<React.OptionHTMLAttributes<HTMLOptionElement>>;
+        return {
+          value: option.props.value ?? "",
+          label: option.props.children,
+          disabled: option.props.disabled,
+        };
+      });
+
+    const selected = options.find((o) => o.value === value);
+
+    const highlightBg =
       colorMode === "dark" ? `${accentColor}.600` : `${accentColor}.200`;
-    const optionHighlightColor =
+    const highlightColor =
       colorMode === "dark" ? "white" : "gray.800";
+    const focusBorderColor =
+      colorMode === "dark" ? `${accentColor}.300` : `${accentColor}.400`;
+
+    const handleChange = (val: string | string[]) => {
+      const stringVal = Array.isArray(val) ? val[0] : val;
+      const syntheticEvent = {
+        target: { value: stringVal },
+      } as ChangeEvent<HTMLSelectElement>;
+      onChange?.(syntheticEvent);
+    };
 
     return (
-      <ChakraSelect
-        ref={ref}
-        colorScheme={accentColor}
-        focusBorderColor={computedFocusBorderColor}
-        sx={{
-          option: {
-            backgroundColor: optionBg,
-          },
-          "option:checked, option:hover, option:focus, option:active": {
-            backgroundColor: `${optionHighlightBg} !important`,
-            color: `${optionHighlightColor} !important`,
-          },
-        }}
-        {...props}
-      />
+      <Menu matchWidth>
+        <MenuButton
+          as={Button}
+          ref={ref}
+          rightIcon={<ChevronDownIcon />}
+          variant="outline"
+          textAlign="left"
+          _focus={{
+            borderColor: focusBorderColor,
+            boxShadow: `0 0 0 1px ${focusBorderColor}`,
+          }}
+          {...props}
+        >
+          {selected ? selected.label : placeholder}
+        </MenuButton>
+        <MenuList zIndex={10}>
+          <MenuOptionGroup
+            type="radio"
+            value={value}
+            onChange={handleChange}
+          >
+            {options.map((o) => (
+              <MenuItemOption
+                key={o.value}
+                value={o.value}
+                isDisabled={o.disabled}
+                _focus={{ bg: highlightBg, color: highlightColor }}
+                _active={{ bg: highlightBg, color: highlightColor }}
+                _hover={{ bg: highlightBg, color: highlightColor }}
+                _checked={{ bg: highlightBg, color: highlightColor }}
+              >
+                {o.label}
+              </MenuItemOption>
+            ))}
+          </MenuOptionGroup>
+        </MenuList>
+      </Menu>
     );
   }
 );

--- a/src/components/ui/Select/index.tsx
+++ b/src/components/ui/Select/index.tsx
@@ -15,12 +15,26 @@ const Select = forwardRef<HTMLSelectElement, SelectProps>(
     const computedFocusBorderColor =
       focusBorderColor ??
       (colorMode === "dark" ? `${accentColor}.300` : `${accentColor}.400`);
+    const optionBg = colorMode === "dark" ? "gray.700" : "white";
+    const optionHighlightBg =
+      colorMode === "dark" ? `${accentColor}.600` : `${accentColor}.200`;
+    const optionHighlightColor =
+      colorMode === "dark" ? "white" : "gray.800";
 
     return (
       <ChakraSelect
         ref={ref}
         colorScheme={accentColor}
         focusBorderColor={computedFocusBorderColor}
+        sx={{
+          option: {
+            backgroundColor: optionBg,
+          },
+          "option:checked, option:hover": {
+            backgroundColor: optionHighlightBg,
+            color: optionHighlightColor,
+          },
+        }}
         {...props}
       />
     );

--- a/src/components/ui/Select/index.tsx
+++ b/src/components/ui/Select/index.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { forwardRef } from "react";
+import {
+  Select as ChakraSelect,
+  type SelectProps,
+  useColorMode,
+} from "@chakra-ui/react";
+import { useAccentColor } from "@/stores";
+
+const Select = forwardRef<HTMLSelectElement, SelectProps>(
+  ({ focusBorderColor, ...props }, ref) => {
+    const { accentColor } = useAccentColor();
+    const { colorMode } = useColorMode();
+    const computedFocusBorderColor =
+      focusBorderColor ??
+      (colorMode === "dark" ? `${accentColor}.300` : `${accentColor}.400`);
+
+    return (
+      <ChakraSelect
+        ref={ref}
+        colorScheme={accentColor}
+        focusBorderColor={computedFocusBorderColor}
+        {...props}
+      />
+    );
+  }
+);
+
+Select.displayName = "Select";
+
+export default Select;

--- a/src/components/ui/Select/index.tsx
+++ b/src/components/ui/Select/index.tsx
@@ -30,9 +30,9 @@ const Select = forwardRef<HTMLSelectElement, SelectProps>(
           option: {
             backgroundColor: optionBg,
           },
-          "option:checked, option:hover": {
-            backgroundColor: optionHighlightBg,
-            color: optionHighlightColor,
+          "option:checked, option:hover, option:focus, option:active": {
+            backgroundColor: `${optionHighlightBg} !important`,
+            color: `${optionHighlightColor} !important`,
           },
         }}
         {...props}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -10,6 +10,7 @@ import MenuItem from "./MenuItem";
 import MenuList from "./MenuList";
 import ImageModal from "./ImageModal";
 import Switch from "./Switch";
+import Select from "./Select";
 
 export {
   Button,
@@ -24,4 +25,5 @@ export {
   MenuList,
   ImageModal,
   Switch,
+  Select,
 };


### PR DESCRIPTION
## Summary
- create Select UI component with accent color scheme
- use new Select in Voice and Accessibility settings
- export Select from UI module

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b301a47030832786cc671d839d9d39