### PR TITLE
Replace select with menu for TTS voice setting

### DIFF
--- a/src/components/ui/Menu/index.tsx
+++ b/src/components/ui/Menu/index.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { Menu as ChakraMenu, type MenuProps } from "@chakra-ui/react";
+
+const Menu = (props: MenuProps) => <ChakraMenu {...props} />;
+
+export default Menu;

--- a/src/components/ui/MenuButton/index.tsx
+++ b/src/components/ui/MenuButton/index.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { forwardRef } from "react";
+import {
+  MenuButton as ChakraMenuButton,
+  Button as ChakraButton,
+  type MenuButtonProps,
+} from "@chakra-ui/react";
+import { useAccentColor } from "@/stores";
+
+const MenuButton = forwardRef<HTMLButtonElement, MenuButtonProps>((props, ref) => {
+  const { accentColor } = useAccentColor();
+  return (
+    <ChakraMenuButton
+      ref={ref}
+      as={ChakraButton}
+      colorScheme={accentColor}
+      {...props}
+    />
+  );
+});
+
+MenuButton.displayName = "MenuButton";
+
+export default MenuButton;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -8,6 +8,8 @@ import AlertDialogContent from "./AlertDialogContent";
 import ModalContent from "./ModalContent";
 import MenuItem from "./MenuItem";
 import MenuList from "./MenuList";
+import Menu from "./Menu";
+import MenuButton from "./MenuButton";
 import ImageModal from "./ImageModal";
 import Switch from "./Switch";
 
@@ -22,6 +24,8 @@ export {
   ModalContent,
   MenuItem,
   MenuList,
+  Menu,
+  MenuButton,
   ImageModal,
   Switch,
 };


### PR DESCRIPTION
## Summary
- add reusable Menu and MenuButton components
- switch TTS voice selector to Menu with highlighted current option

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b30fc29a2883279939689924078492