### PR TITLE
Use outline variant for voice menu button

### DIFF
--- a/src/components/Settings/VoiceAndAccessibility.tsx
+++ b/src/components/Settings/VoiceAndAccessibility.tsx
@@ -140,6 +140,7 @@ const VoiceAndAccessibility: FC = () => {
                   }))}
                   placeholder="Default"
                   buttonProps={{
+                    variant: "outline",
                     w: "full",
                     maxW: { base: "100%", md: "sm" },
                   }}


### PR DESCRIPTION
## Summary
- show TTS menu with outline button variant

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4ea22b5c48327b5fa638605b8b0c1