### PR TITLE
Use custom Menu variants in voice and navigation settings

### DIFF
--- a/src/components/NavigationBar/index.tsx
+++ b/src/components/NavigationBar/index.tsx
@@ -3,7 +3,6 @@
 import { FC, Fragment, memo, useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 
-import { HiOutlineChevronDown } from "react-icons/hi";
 import { IoMdMenu } from "react-icons/io";
 import { RiChat3Line, RiChatHistoryFill } from "react-icons/ri";
 
@@ -12,15 +11,13 @@ import {
   Divider,
   Flex,
   IconButton,
-  Menu,
-  MenuButton,
   Text,
   useDisclosure,
 } from "@chakra-ui/react";
 
 import { supabase, GEMINI_MODELS } from "@/lib";
 import { useAuth, useModel, useToastStore } from "@/stores";
-import { Button, MenuItem, MenuList } from "@themed-components";
+import { Button, Menu } from "@/components/ui";
 import { SideBar } from "@/components";
 
 interface Thread {
@@ -44,8 +41,6 @@ const NavigationBar: FC = () => {
       .replace(/^gemini/i, "Gemini")
       .replace(/-/g, " ")
       .replace(/\b(\w)/g, (match) => match.toUpperCase());
-
-  const formattedModel = formatModel(model);
 
   useEffect(() => {
     if (!user) {
@@ -151,34 +146,29 @@ const NavigationBar: FC = () => {
               <Text fontSize="lg" fontWeight="bold" noOfLines={1} px={1}>
                 {pathname === "/" ? "Xeenapz" : pathname === "/thread/temp" ? "Temporary Chat" : currentThreadTitle || "Xeenapz"}
               </Text>
-              {user && (
-                <Menu>
-                  <MenuButton
-                    as={Button}
-                    size="xs"
-                    variant="ghost"
-                    color="secondaryText"
-                    colorScheme="gray"
-                    px={1}
-                    maxW="100%"
-                    overflow="hidden"
-                    textOverflow="ellipsis"
-                    whiteSpace="nowrap"
-                    rightIcon={<HiOutlineChevronDown />}
-                  >
-                    {formattedModel}
-                  </MenuButton>
-                  <MenuList>
-                    {GEMINI_MODELS.map((m) => (
-                      <MenuItem key={m} onClick={() => setModel(m)}>
-                        {formatModel(m)}
-                      </MenuItem>
-                    ))}
-                  </MenuList>
-                </Menu>
-              )}
+                {user && (
+                  <Menu
+                    items={GEMINI_MODELS.map((m) => ({
+                      value: m,
+                      label: formatModel(m),
+                    }))}
+                    value={model}
+                    onChange={(value) => {
+                      if (value) setModel(value);
+                    }}
+                    placeholder="Select Model"
+                    includeNullOption={false}
+                    buttonProps={{
+                      size: "xs",
+                      variant: "ghost",
+                      color: "secondaryText",
+                      px: 1,
+                      w: "auto",
+                    }}
+                  />
+                )}
+              </Flex>
             </Flex>
-          </Flex>
 
           <Flex align="center" gap={4} flexShrink={0}>
             {user && (pathname === "/" || pathname === "/thread/temp") && (

--- a/src/components/Settings/VoiceAndAccessibility.tsx
+++ b/src/components/Settings/VoiceAndAccessibility.tsx
@@ -140,8 +140,7 @@ const VoiceAndAccessibility: FC = () => {
                   }))}
                   placeholder="Default"
                   buttonProps={{
-                    w: "full",
-                    maxW: { base: "100%", md: "sm" },
+                    variant: "outline",
                   }}
                 />
               }

--- a/src/components/ui/Menu/index.tsx
+++ b/src/components/ui/Menu/index.tsx
@@ -24,6 +24,7 @@ interface MenuProps extends Omit<ChakraMenuProps, "children"> {
   value: string | null;
   onChange: (value: string | null) => void | Promise<void>;
   placeholder?: string;
+  includeNullOption?: boolean;
   buttonProps?: ButtonProps;
 }
 
@@ -32,6 +33,7 @@ const Menu = ({
   value,
   onChange,
   placeholder = "Select...",
+  includeNullOption = true,
   buttonProps,
   ...props
 }: MenuProps) => {
@@ -44,7 +46,7 @@ const Menu = ({
     colorMode === "dark" ? `${accentColor}.300` : `${accentColor}.500`;
 
   return (
-    <ChakraMenu initialFocusRef={selectedRef} {...props}>
+    <ChakraMenu matchWidth initialFocusRef={selectedRef} {...props}>
       <ChakraMenuButton
         as={Button}
         colorScheme="gray"
@@ -57,20 +59,23 @@ const Menu = ({
         {selectedLabel}
       </ChakraMenuButton>
       <MenuList maxH="200px" overflowY="auto">
-        <MenuItem
-          ref={value === null ? selectedRef : undefined}
-          onClick={() => onChange(null)}
-          color={value === null ? selectedColor : undefined}
-        >
-          {placeholder}
-        </MenuItem>
+        {includeNullOption && (
+          <MenuItem
+            ref={value === null ? selectedRef : undefined}
+            onClick={() => onChange(null)}
+            color={value === null ? selectedColor : undefined}
+            w="full"
+          >
+            {placeholder}
+          </MenuItem>
+        )}
         {items.map((item) => (
           <MenuItem
             key={item.value}
             ref={item.value === value ? selectedRef : undefined}
             onClick={() => onChange(item.value)}
             color={item.value === value ? selectedColor : undefined}
-
+            w="full"
           >
             {item.label}
           </MenuItem>


### PR DESCRIPTION
## Summary
- show TTS menu with outline button variant
- use custom Menu in NavigationBar with ghost button variant
- allow shared Menu to hide placeholder option and remove "Select Model" from model list

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4ea22b5c48327b5fa638605b8b0c1