### PR TITLE
fix(ui): sync menu width to items

### DIFF
--- a/src/components/Settings/VoiceAndAccessibility.tsx
+++ b/src/components/Settings/VoiceAndAccessibility.tsx
@@ -34,10 +34,10 @@ const SettingRow = ({
 }) => {
   return (
     <Grid
-      templateColumns="1fr auto"
+      templateColumns={{ base: "1fr", md: "1fr auto" }}
       columnGap={4}
       rowGap={1}
-      alignItems="center"
+      alignItems={{ md: "center" }}
     >
       <Box minW={0}>
         <Text fontWeight="medium">{label}</Text>
@@ -53,7 +53,12 @@ const SettingRow = ({
         )}
       </Box>
 
-      <Flex justify="flex-end">{control}</Flex>
+      <Flex
+        justify={{ base: "flex-start", md: "flex-end" }}
+        w={{ base: "full", md: "auto" }}
+      >
+        {control}
+      </Flex>
     </Grid>
   );
 };
@@ -135,6 +140,7 @@ const VoiceAndAccessibility: FC = () => {
                   placeholder="Default"
                   buttonProps={{
                     variant: "outline",
+                    w: { base: "full", md: "auto" },
                   }}
                 />
               }

--- a/src/components/Settings/VoiceAndAccessibility.tsx
+++ b/src/components/Settings/VoiceAndAccessibility.tsx
@@ -34,10 +34,10 @@ const SettingRow = ({
 }) => {
   return (
     <Grid
-      templateColumns={{ base: "1fr", md: "1fr auto" }} // stack on mobile
+      templateColumns="1fr auto"
       columnGap={4}
-      rowGap={{ base: 3, md: 1 }}
-      alignItems={{ base: "start", md: "center" }}
+      rowGap={1}
+      alignItems="center"
     >
       <Box minW={0}>
         <Text fontWeight="medium">{label}</Text>
@@ -53,13 +53,7 @@ const SettingRow = ({
         )}
       </Box>
 
-      <Flex
-        justify={{ base: "stretch", md: "flex-end" }}
-        minW={{ base: 0, md: "fit-content" }}
-        w={{ base: "full", md: "auto" }}
-      >
-        {control}
-      </Flex>
+      <Flex justify="flex-end">{control}</Flex>
     </Grid>
   );
 };

--- a/src/components/ui/Menu/index.tsx
+++ b/src/components/ui/Menu/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useLayoutEffect, useMemo } from "react";
+import { useRef } from "react";
 import {
   Menu as ChakraMenu,
   MenuButton as ChakraMenuButton,
@@ -45,80 +45,41 @@ const Menu = ({
   const selectedColor =
     colorMode === "dark" ? `${accentColor}.300` : `${accentColor}.500`;
 
-  const measureRef = useRef<HTMLButtonElement>(null);
-  const [menuWidth, setMenuWidth] = useState<string>();
-  const longestLabel = useMemo(() => {
-    const labels = items.map((i) => i.label);
-    if (includeNullOption) labels.push(placeholder);
-    return labels.reduce((a, b) => (a.length > b.length ? a : b), "");
-  }, [items, includeNullOption, placeholder]);
-
-  useLayoutEffect(() => {
-    if (measureRef.current) {
-      setMenuWidth(`${measureRef.current.getBoundingClientRect().width}px`);
-    }
-  }, [longestLabel, buttonProps]);
-
   return (
-    <>
-      <Button
-        ref={measureRef}
+    <ChakraMenu initialFocusRef={selectedRef} matchWidth {...props}>
+      <ChakraMenuButton
+        as={Button}
         colorScheme="gray"
         variant="solid"
         textAlign="left"
         rightIcon={<HiOutlineChevronDown />}
+        w="full"
         {...buttonProps}
-        size="md"
-        fontSize="md"
-        px={3}
-        w="auto"
-        position="absolute"
-        visibility="hidden"
-        pointerEvents="none"
-        whiteSpace="nowrap"
       >
-        {longestLabel}
-      </Button>
-      <ChakraMenu initialFocusRef={selectedRef} {...props}>
-        <ChakraMenuButton
-          as={Button}
-          colorScheme="gray"
-          variant="solid"
-          textAlign="left"
-          rightIcon={<HiOutlineChevronDown />}
-          {...buttonProps}
-          w={{ base: "full", md: menuWidth }}
-        >
-          {selectedLabel}
-        </ChakraMenuButton>
-        <MenuList
-          maxH="200px"
-          overflowY="auto"
-          w={{ base: "full", md: menuWidth }}
-          minW="0"
-        >
-          {includeNullOption && (
-            <MenuItem
-              ref={value === null ? selectedRef : undefined}
-              onClick={() => onChange(null)}
-              color={value === null ? selectedColor : undefined}
+        {selectedLabel}
+      </ChakraMenuButton>
+      <MenuList maxH="200px" overflowY="auto" w="full" minW="0">
+        {includeNullOption && (
+          <MenuItem
+            ref={value === null ? selectedRef : undefined}
+            onClick={() => onChange(null)}
+            color={value === null ? selectedColor : undefined}
           >
             {placeholder}
           </MenuItem>
         )}
-          {items.map((item) => (
-            <MenuItem
-              key={item.value}
-              ref={item.value === value ? selectedRef : undefined}
-              onClick={() => onChange(item.value)}
-              color={item.value === value ? selectedColor : undefined}
-            >
-              {item.label}
-            </MenuItem>
-          ))}
-        </MenuList>
-      </ChakraMenu>
-    </>
+        {items.map((item) => (
+          <MenuItem
+            key={item.value}
+            ref={item.value === value ? selectedRef : undefined}
+            onClick={() => onChange(item.value)}
+            color={item.value === value ? selectedColor : undefined}
+          >
+            {item.label}
+          </MenuItem>
+        ))}
+      </MenuList>
+    </ChakraMenu>
   );
 };
 

--- a/src/components/ui/Menu/index.tsx
+++ b/src/components/ui/Menu/index.tsx
@@ -68,6 +68,9 @@ const Menu = ({
         textAlign="left"
         rightIcon={<HiOutlineChevronDown />}
         {...buttonProps}
+        size="md"
+        fontSize="md"
+        px={3}
         w="auto"
         position="absolute"
         visibility="hidden"

--- a/src/components/ui/Menu/index.tsx
+++ b/src/components/ui/Menu/index.tsx
@@ -58,7 +58,7 @@ const Menu = ({
       >
         {selectedLabel}
       </ChakraMenuButton>
-      <MenuList maxH="200px" overflowY="auto" w="full" minW="0">
+      <MenuList>
         {includeNullOption && (
           <MenuItem
             ref={value === null ? selectedRef : undefined}

--- a/src/components/ui/Menu/index.tsx
+++ b/src/components/ui/Menu/index.tsx
@@ -87,11 +87,16 @@ const Menu = ({
           textAlign="left"
           rightIcon={<HiOutlineChevronDown />}
           {...buttonProps}
-          w={menuWidth}
+          w={{ base: "full", md: menuWidth }}
         >
           {selectedLabel}
         </ChakraMenuButton>
-        <MenuList maxH="200px" overflowY="auto" w={menuWidth} minW="0">
+        <MenuList
+          maxH="200px"
+          overflowY="auto"
+          w={{ base: "full", md: menuWidth }}
+          minW="0"
+        >
           {includeNullOption && (
             <MenuItem
               ref={value === null ? selectedRef : undefined}

--- a/src/components/ui/Menu/index.tsx
+++ b/src/components/ui/Menu/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useState, useLayoutEffect, useMemo } from "react";
 import {
   Menu as ChakraMenu,
   MenuButton as ChakraMenuButton,
@@ -45,41 +45,72 @@ const Menu = ({
   const selectedColor =
     colorMode === "dark" ? `${accentColor}.300` : `${accentColor}.500`;
 
+  const measureRef = useRef<HTMLButtonElement>(null);
+  const [menuWidth, setMenuWidth] = useState<string>();
+  const longestLabel = useMemo(() => {
+    const labels = items.map((i) => i.label);
+    if (includeNullOption) labels.push(placeholder);
+    return labels.reduce((a, b) => (a.length > b.length ? a : b), "");
+  }, [items, includeNullOption, placeholder]);
+
+  useLayoutEffect(() => {
+    if (measureRef.current) {
+      setMenuWidth(`${measureRef.current.getBoundingClientRect().width}px`);
+    }
+  }, [longestLabel, buttonProps]);
+
   return (
-    <ChakraMenu initialFocusRef={selectedRef} {...props}>
-      <ChakraMenuButton
-        as={Button}
+    <>
+      <Button
+        ref={measureRef}
         colorScheme="gray"
-        w="full"
         variant="solid"
         textAlign="left"
         rightIcon={<HiOutlineChevronDown />}
         {...buttonProps}
+        w="auto"
+        position="absolute"
+        visibility="hidden"
+        pointerEvents="none"
+        whiteSpace="nowrap"
       >
-        {selectedLabel}
-      </ChakraMenuButton>
-      <MenuList maxH="200px" overflowY="auto">
-        {includeNullOption && (
-          <MenuItem
-            ref={value === null ? selectedRef : undefined}
-            onClick={() => onChange(null)}
-            color={value === null ? selectedColor : undefined}
+        {longestLabel}
+      </Button>
+      <ChakraMenu initialFocusRef={selectedRef} {...props}>
+        <ChakraMenuButton
+          as={Button}
+          colorScheme="gray"
+          variant="solid"
+          textAlign="left"
+          rightIcon={<HiOutlineChevronDown />}
+          {...buttonProps}
+          w={menuWidth}
+        >
+          {selectedLabel}
+        </ChakraMenuButton>
+        <MenuList maxH="200px" overflowY="auto" w={menuWidth} minW="0">
+          {includeNullOption && (
+            <MenuItem
+              ref={value === null ? selectedRef : undefined}
+              onClick={() => onChange(null)}
+              color={value === null ? selectedColor : undefined}
           >
             {placeholder}
           </MenuItem>
         )}
-        {items.map((item) => (
-          <MenuItem
-            key={item.value}
-            ref={item.value === value ? selectedRef : undefined}
-            onClick={() => onChange(item.value)}
-            color={item.value === value ? selectedColor : undefined}
-          >
-            {item.label}
-          </MenuItem>
-        ))}
-      </MenuList>
-    </ChakraMenu>
+          {items.map((item) => (
+            <MenuItem
+              key={item.value}
+              ref={item.value === value ? selectedRef : undefined}
+              onClick={() => onChange(item.value)}
+              color={item.value === value ? selectedColor : undefined}
+            >
+              {item.label}
+            </MenuItem>
+          ))}
+        </MenuList>
+      </ChakraMenu>
+    </>
   );
 };
 

--- a/src/components/ui/MenuItem/index.tsx
+++ b/src/components/ui/MenuItem/index.tsx
@@ -23,6 +23,7 @@ const MenuItem = forwardRef<HTMLDivElement, MenuItemProps>((props, ref) => {
       _focus={{
         bgColor: colorMode === "dark" ? "gray.700" : "gray.100",
       }}
+      whiteSpace="nowrap"
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- measure widest menu item and apply its width to the trigger and list

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b53df665848327a17a287233dcba0f