### PR TITLE
Fix menu button icon overlap on small widths

### DIFF
--- a/src/components/ui/Menu/index.tsx
+++ b/src/components/ui/Menu/index.tsx
@@ -2,6 +2,7 @@
 
 import { useRef } from "react";
 import {
+  Box,
   Menu as ChakraMenu,
   MenuButton as ChakraMenuButton,
   type MenuProps as ChakraMenuProps,
@@ -52,11 +53,21 @@ const Menu = ({
         colorScheme="gray"
         w="full"
         variant="solid"
-        textAlign="left"
+        justifyContent="space-between"
+        overflow="hidden"
         rightIcon={<HiOutlineChevronDown />}
         {...buttonProps}
       >
-        {selectedLabel}
+        <Box
+          flex="1"
+          textAlign="left"
+          minW={0}
+          textOverflow="ellipsis"
+          overflow="hidden"
+          whiteSpace="nowrap"
+        >
+          {selectedLabel}
+        </Box>
       </ChakraMenuButton>
       <MenuList maxH="200px" overflowY="auto">
         {includeNullOption && (


### PR DESCRIPTION
## Summary
- prevent menu placeholder text from hiding dropdown icon on narrow widths
- add ellipsis truncation for long menu labels

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6823f847c8327a1837dae27204301