### PR TITLE
feat: add Data & Privacy thread deletion

### DIFF
--- a/src/components/Settings/Appearance.tsx
+++ b/src/components/Settings/Appearance.tsx
@@ -235,7 +235,7 @@ const Appearance: FC = () => {
         </CardHeader>
         <Divider />
         <CardBody p={4}>
-          <Flex direction="column" gap={6}>
+          <Flex direction="column" gap={4}>
             <Flex direction="column" gap={3}>
               <SectionText
                 title="Color Mode"

--- a/src/components/Settings/DataAndPrivacy.tsx
+++ b/src/components/Settings/DataAndPrivacy.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { FC, useRef, useState } from "react";
+import {
+  Box,
+  Card,
+  CardHeader,
+  CardBody,
+  Divider,
+  Flex,
+  Grid,
+  Text,
+  useDisclosure,
+  AlertDialog,
+  AlertDialogOverlay,
+  AlertDialogHeader,
+  AlertDialogBody,
+  AlertDialogFooter,
+  HStack,
+} from "@chakra-ui/react";
+import { Button, AlertDialogContent } from "@themed-components";
+import { useAuth, useToastStore } from "@/stores";
+import { supabase } from "@/lib";
+import { useRouter, usePathname } from "next/navigation";
+
+const SettingRow = ({
+  label,
+  description,
+  control,
+}: {
+  label: string;
+  description?: string;
+  control: React.ReactNode;
+}) => {
+  return (
+    <Grid
+      templateColumns="1fr auto"
+      columnGap={4}
+      rowGap={1}
+      alignItems="center"
+    >
+      <Box minW={0}>
+        <Text fontWeight="medium">{label}</Text>
+        {description && (
+          <Text
+            mt={1}
+            fontSize="xs"
+            color="secondaryText"
+            wordBreak="break-word"
+          >
+            {description}
+          </Text>
+        )}
+      </Box>
+
+      <Flex justify="flex-end" minW="fit-content">
+        {control}
+      </Flex>
+    </Grid>
+  );
+};
+
+const DataAndPrivacy: FC = () => {
+  const { user } = useAuth();
+  const { showToast } = useToastStore();
+  const router = useRouter();
+  const pathname = usePathname();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDeleteAll = async () => {
+    if (!user) return;
+
+    try {
+      setIsDeleting(true);
+
+      if (pathname?.startsWith("/thread")) {
+        router.push("/");
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+
+      const { data: threads, error: threadsError } = await supabase
+        .from("threads")
+        .select("id")
+        .eq("user_id", user.id);
+      if (threadsError) throw threadsError;
+
+      await supabase.from("messages").delete().eq("user_id", user.id);
+
+      if (threads) {
+        for (const { id } of threads) {
+          const { data: files, error: listError } = await supabase.storage
+            .from("messages")
+            .list(`${user.id}/${id}`);
+
+          if (listError) {
+            console.error("Failed to list images:", listError);
+            continue;
+          }
+
+          if (files && files.length > 0) {
+            const paths = files.map((file) => `${user.id}/${id}/${file.name}`);
+            const { error: removeError } = await supabase.storage
+              .from("messages")
+              .remove(paths);
+            if (removeError) {
+              console.error("Failed to remove images:", removeError);
+            }
+          }
+        }
+      }
+
+      await supabase.from("threads").delete().eq("user_id", user.id);
+
+      onClose();
+      showToast({
+        id: "delete-all-threads",
+        title: "All threads deleted",
+        status: "success",
+      });
+    } catch (err) {
+      console.error("Failed to delete threads:", err);
+      showToast({
+        id: "delete-all-threads-error",
+        title: "Failed to delete",
+        description: "An error occurred while deleting your threads.",
+        status: "error",
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <Flex direction="column" gap={4}>
+      <Card bg="transparent" variant="outline">
+        <CardHeader px={4} py={3}>
+          <Text fontWeight="semibold" fontSize="lg">
+            Data Management
+          </Text>
+        </CardHeader>
+        <Divider />
+        <CardBody p={4}>
+          <Flex direction="column" gap={6}>
+            <SettingRow
+              label="Delete All Threads"
+              description="Permanently remove all of your threads."
+              control={
+                <Button
+                  variant="outline"
+                  colorScheme="red"
+                  onClick={onOpen}
+                >
+                  Delete
+                </Button>
+              }
+            />
+          </Flex>
+        </CardBody>
+      </Card>
+
+      <AlertDialog
+        isOpen={isOpen}
+        leastDestructiveRef={cancelRef}
+        onClose={onClose}
+        isCentered
+      >
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader fontSize="lg" fontWeight="bold">
+              Delete All Threads
+            </AlertDialogHeader>
+            <AlertDialogBody>
+              Are you sure you want to delete all your threads? This action
+              cannot be undone.
+            </AlertDialogBody>
+            <AlertDialogFooter>
+              <HStack gap={4}>
+                <Button
+                  variant="ghost"
+                  colorScheme="gray"
+                  onClick={onClose}
+                  ref={cancelRef}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="ghost"
+                  colorScheme="red"
+                  onClick={handleDeleteAll}
+                  isLoading={isDeleting}
+                >
+                  Delete
+                </Button>
+              </HStack>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
+    </Flex>
+  );
+};
+
+export default DataAndPrivacy;
+

--- a/src/components/Settings/DataAndPrivacy.tsx
+++ b/src/components/Settings/DataAndPrivacy.tsx
@@ -192,10 +192,9 @@ const DataAndPrivacy: FC = () => {
             <SettingRow
               label="Archive All Threads"
               description="Move all your threads to the archive."
-              control={
-                <Button onClick={onArchiveOpen}>Archive</Button>
-              }
+              control={<Button onClick={onArchiveOpen}>Archive</Button>}
             />
+            <Divider />
             <SettingRow
               label="Delete All Threads"
               description="Permanently remove all of your threads."
@@ -289,4 +288,3 @@ const DataAndPrivacy: FC = () => {
 };
 
 export default DataAndPrivacy;
-

--- a/src/components/Settings/DataAndPrivacy.tsx
+++ b/src/components/Settings/DataAndPrivacy.tsx
@@ -188,7 +188,7 @@ const DataAndPrivacy: FC = () => {
         </CardHeader>
         <Divider />
         <CardBody p={4}>
-          <Flex direction="column" gap={6}>
+          <Flex direction="column" gap={4}>
             <SettingRow
               label="Archive All Threads"
               description="Move all your threads to the archive."

--- a/src/components/Settings/General.tsx
+++ b/src/components/Settings/General.tsx
@@ -112,7 +112,7 @@ const General: FC = () => {
         </CardHeader>
         <Divider />
         <CardBody p={4}>
-          <Flex direction="column" gap={6}>
+          <Flex direction="column" gap={4}>
             <SettingRow
               label="Smart Suggestions"
               description="Show quick follow-up suggestions after assistant responses."

--- a/src/components/Settings/VoiceAndAccessibility.tsx
+++ b/src/components/Settings/VoiceAndAccessibility.tsx
@@ -115,7 +115,7 @@ const VoiceAndAccessibility: FC = () => {
         </CardHeader>
         <Divider />
         <CardBody p={4}>
-          <Flex direction="column" gap={6}>
+          <Flex direction="column" gap={4}>
             <SettingRow
               label="Text-to-Speech"
               description="Choose the voice for text-to-speech playback."

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -29,6 +29,7 @@ import { HiLockClosed, HiOutlineLockClosed, HiOutlineUser } from "react-icons/hi
 import Appearance from "./Appearance";
 import General from "./General";
 import VoiceAndAccessibility from "./VoiceAndAccessibility";
+import DataAndPrivacy from "./DataAndPrivacy";
 
 interface SettingsProps {
   isOpen: boolean;
@@ -201,7 +202,9 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
                 <VoiceAndAccessibility />
               </TabPanel>
               <TabPanel>Chat preferences go here.</TabPanel>
-              <TabPanel>Data & Privacy settings go here.</TabPanel>
+              <TabPanel>
+                <DataAndPrivacy />
+              </TabPanel>
               <TabPanel>Account settings go here.</TabPanel>
               <TabPanel>Advanced settings go here.</TabPanel>
               <TabPanel>About info goes here.</TabPanel>


### PR DESCRIPTION
## Summary
- add DataAndPrivacy settings panel with option to delete all threads for current user
- wire Data & Privacy tab in settings modal to new component

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b687b1f9688327bf074db2f0c83050