### PR TITLE
feat(settings): add about section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,19 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Issue Tracker
+
+Found a bug or have a feature request? Let us know by [opening an issue](https://github.com/owner/repo/issues) on GitHub.
+
+## Release Notes
+
+Stay up to date with new versions by checking the [release notes](https://github.com/owner/repo/releases).
+
+## Documentation
+
+Learn how to use and extend this project in the [documentation](https://github.com/owner/repo#readme).
+
+## Licenses & Credits
+
+This project uses open‑source software. See the [LICENSE](https://github.com/owner/repo/blob/main/LICENSE) and [credits](https://github.com/owner/repo#credits) for details.

--- a/src/components/Settings/About.tsx
+++ b/src/components/Settings/About.tsx
@@ -7,64 +7,187 @@ import {
   CardBody,
   Divider,
   Flex,
+  Grid,
+  Box,
   Text,
+  Code,
   Link,
+  Icon,
+  HStack,
+  Button,
+  useColorModeValue,
 } from "@chakra-ui/react";
+import { FiExternalLink, FiCopy } from "react-icons/fi";
 import packageJson from "../../../package.json";
 
+// Optional build/env metadata (fallbacks are safe)
+const BUILD_SHA = process.env.NEXT_PUBLIC_BUILD_SHA ?? "";
+const BUILD_DATE = process.env.NEXT_PUBLIC_BUILD_DATE ?? "";
+
+const RELEASE_NOTES_URL = "https://github.com/owner/repo/releases";
+const ISSUES_URL = "https://github.com/owner/repo/issues";
+const LICENSE_URL = "https://github.com/owner/repo/blob/main/LICENSE";
+const CREDITS_URL = "https://github.com/owner/repo#credits";
+const DOCS_URL = "https://github.com/owner/repo#readme";
+const SUPPORT_EMAIL = "developer@example.com";
+
+const InfoRow = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => {
+  return (
+    <Grid
+      templateColumns={{ base: "1fr", sm: "200px 1fr" }}
+      columnGap={4}
+      rowGap={1.5}
+      alignItems="center"
+    >
+      <Text fontWeight="medium">{label}</Text>
+      <Box minW={0}>{children}</Box>
+    </Grid>
+  );
+};
+
+const CopyButton = ({
+  value,
+  "aria-label": ariaLabel,
+}: {
+  value: string;
+  "aria-label"?: string;
+}) => (
+  <Button
+    size="xs"
+    variant="ghost"
+    leftIcon={<FiCopy />}
+    aria-label={ariaLabel ?? "Copy value"}
+    onClick={() => navigator.clipboard.writeText(value)}
+  >
+    Copy
+  </Button>
+);
+
+const External = ({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) => (
+  <Link
+    href={href}
+    isExternal
+    display="inline-flex"
+    alignItems="center"
+    gap={1}
+  >
+    {children}
+    <Icon as={FiExternalLink} aria-hidden />
+  </Link>
+);
+
 const About: FC = () => {
+  const muted = useColorModeValue("gray.600", "gray.400");
+  const sectionTitle = (title: string) => (
+    <Text fontWeight="semibold" fontSize="lg">
+      {title}
+    </Text>
+  );
+
   return (
     <Flex direction="column" gap={4}>
+      {/* About this app */}
       <Card bg="transparent" variant="outline">
         <CardHeader px={4} py={3}>
-          <Text fontWeight="semibold" fontSize="lg">
-            App Version / Release Notes
-          </Text>
+          {sectionTitle("About this app")}
         </CardHeader>
         <Divider />
         <CardBody p={4}>
-          <Text>Version: {packageJson.version}</Text>
-          <Text mt={2}>
-            See{' '}
-            <Link href="https://github.com/owner/repo/releases" isExternal>
-              release notes
-            </Link>
-            .
-          </Text>
-        </CardBody>
-      </Card>
+          <Flex direction="column" gap={4}>
+            <InfoRow label="Version">
+              <HStack spacing={3} wrap="wrap">
+                <Code>{packageJson.version}</Code>
+                <CopyButton
+                  value={packageJson.version}
+                  aria-label="Copy version"
+                />
+              </HStack>
+            </InfoRow>
 
-      <Card bg="transparent" variant="outline">
-        <CardHeader px={4} py={3}>
-          <Text fontWeight="semibold" fontSize="lg">
-            Contact Developer
-          </Text>
-        </CardHeader>
-        <Divider />
-        <CardBody p={4}>
-          <Flex direction="column" gap={2}>
-            <Link href="mailto:developer@example.com">
-              developer@example.com
-            </Link>
-            <Link href="https://github.com/owner/repo/issues" isExternal>
-              GitHub Issues
-            </Link>
+            <InfoRow label="Build">
+              <Flex
+                direction={{ base: "column", sm: "row" }}
+                gap={2}
+                align={{ sm: "center" }}
+              >
+                <HStack spacing={3} wrap="wrap">
+                  <Text fontSize="sm" color={muted}>
+                    {BUILD_DATE ? new Date(BUILD_DATE).toLocaleString() : "—"}
+                  </Text>
+                </HStack>
+                <HStack spacing={3} wrap="wrap">
+                  <Code>{BUILD_SHA ? BUILD_SHA.slice(0, 7) : "—"}</Code>
+                  {BUILD_SHA && (
+                    <CopyButton
+                      value={BUILD_SHA}
+                      aria-label="Copy commit SHA"
+                    />
+                  )}
+                </HStack>
+              </Flex>
+            </InfoRow>
+
+            <InfoRow label="Release notes">
+              <External href={RELEASE_NOTES_URL}>See releases</External>
+            </InfoRow>
+
+            <InfoRow label="Documentation">
+              <External href={DOCS_URL}>Open docs</External>
+            </InfoRow>
           </Flex>
         </CardBody>
       </Card>
 
+      {/* Support */}
       <Card bg="transparent" variant="outline">
         <CardHeader px={4} py={3}>
-          <Text fontWeight="semibold" fontSize="lg">
-            Licenses & Credits
-          </Text>
+          {sectionTitle("Contact & Support")}
         </CardHeader>
         <Divider />
         <CardBody p={4}>
-          <Text>
-            This project uses open source software. See the documentation and
-            third-party licenses for details.
-          </Text>
+          <Flex direction="column" gap={4}>
+            <InfoRow label="Email">
+              <HStack spacing={3} wrap="wrap">
+                <Link href={`mailto:${SUPPORT_EMAIL}`}>{SUPPORT_EMAIL}</Link>
+                <CopyButton value={SUPPORT_EMAIL} aria-label="Copy email" />
+              </HStack>
+            </InfoRow>
+            <InfoRow label="Issue tracker">
+              <External href={ISSUES_URL}>GitHub Issues</External>
+            </InfoRow>
+          </Flex>
+        </CardBody>
+      </Card>
+
+      {/* Legal */}
+      <Card bg="transparent" variant="outline">
+        <CardHeader px={4} py={3}>
+          {sectionTitle("Licenses & Credits")}
+        </CardHeader>
+        <Divider />
+        <CardBody p={4}>
+          <Flex direction="column" gap={2}>
+            <Text>
+              This project uses open-source software. See the documentation and
+              third-party licenses for details.
+            </Text>
+            <HStack spacing={6} wrap="wrap">
+              <External href={LICENSE_URL}>License</External>
+              <External href={CREDITS_URL}>Credits</External>
+            </HStack>
+          </Flex>
         </CardBody>
       </Card>
     </Flex>
@@ -72,3 +195,4 @@ const About: FC = () => {
 };
 
 export default About;
+

--- a/src/components/Settings/About.tsx
+++ b/src/components/Settings/About.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { FC } from "react";
+import {
+  Card,
+  CardHeader,
+  CardBody,
+  Divider,
+  Flex,
+  Text,
+  Link,
+} from "@chakra-ui/react";
+import packageJson from "../../../package.json";
+
+const About: FC = () => {
+  return (
+    <Flex direction="column" gap={4}>
+      <Card bg="transparent" variant="outline">
+        <CardHeader px={4} py={3}>
+          <Text fontWeight="semibold" fontSize="lg">
+            App Version / Release Notes
+          </Text>
+        </CardHeader>
+        <Divider />
+        <CardBody p={4}>
+          <Text>Version: {packageJson.version}</Text>
+          <Text mt={2}>
+            See{' '}
+            <Link href="https://github.com/owner/repo/releases" isExternal>
+              release notes
+            </Link>
+            .
+          </Text>
+        </CardBody>
+      </Card>
+
+      <Card bg="transparent" variant="outline">
+        <CardHeader px={4} py={3}>
+          <Text fontWeight="semibold" fontSize="lg">
+            Contact Developer
+          </Text>
+        </CardHeader>
+        <Divider />
+        <CardBody p={4}>
+          <Flex direction="column" gap={2}>
+            <Link href="mailto:developer@example.com">
+              developer@example.com
+            </Link>
+            <Link href="https://github.com/owner/repo/issues" isExternal>
+              GitHub Issues
+            </Link>
+          </Flex>
+        </CardBody>
+      </Card>
+
+      <Card bg="transparent" variant="outline">
+        <CardHeader px={4} py={3}>
+          <Text fontWeight="semibold" fontSize="lg">
+            Licenses & Credits
+          </Text>
+        </CardHeader>
+        <Divider />
+        <CardBody p={4}>
+          <Text>
+            This project uses open source software. See the documentation and
+            third-party licenses for details.
+          </Text>
+        </CardBody>
+      </Card>
+    </Flex>
+  );
+};
+
+export default About;

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -30,6 +30,7 @@ import Appearance from "./Appearance";
 import General from "./General";
 import VoiceAndAccessibility from "./VoiceAndAccessibility";
 import DataAndPrivacy from "./DataAndPrivacy";
+import About from "./About";
 
 interface SettingsProps {
   isOpen: boolean;
@@ -207,7 +208,9 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
               </TabPanel>
               <TabPanel>Account settings go here.</TabPanel>
               <TabPanel>Advanced settings go here.</TabPanel>
-              <TabPanel>About info goes here.</TabPanel>
+              <TabPanel>
+                <About />
+              </TabPanel>
             </TabPanels>
           </Tabs>
         </ModalBody>


### PR DESCRIPTION
## Summary
- add About settings panel showing version, contact links, and license info
- connect Settings tabs to render the new About panel

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7a15e4f58832799467320e8df69ea