### PR TITLE
Add advanced settings placeholder

### DIFF
--- a/src/components/Settings/Advanced.tsx
+++ b/src/components/Settings/Advanced.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { FC, useRef, useState } from "react";
+import {
+  Box,
+  Card,
+  CardHeader,
+  CardBody,
+  Divider,
+  Flex,
+  Grid,
+  Text,
+  useDisclosure,
+  AlertDialog,
+  AlertDialogOverlay,
+  AlertDialogHeader,
+  AlertDialogBody,
+  AlertDialogFooter,
+  HStack,
+} from "@chakra-ui/react";
+import { Button, AlertDialogContent } from "@themed-components";
+import { useAccentColor, useToastStore } from "@/stores";
+
+const SettingRow = ({
+  label,
+  description,
+  control,
+}: {
+  label: string;
+  description?: string;
+  control: React.ReactNode;
+}) => {
+  return (
+    <Grid
+      templateColumns="1fr auto"
+      columnGap={4}
+      rowGap={1}
+      alignItems="center"
+    >
+      <Box minW={0}>
+        <Text fontWeight="medium">{label}</Text>
+        {description && (
+          <Text
+            mt={1}
+            fontSize="xs"
+            color="secondaryText"
+            wordBreak="break-word"
+          >
+            {description}
+          </Text>
+        )}
+      </Box>
+
+      <Flex justify="flex-end" minW="fit-content">
+        {control}
+      </Flex>
+    </Grid>
+  );
+};
+
+const Advanced: FC = () => {
+  const { setAccentColor } = useAccentColor();
+  const { showToast } = useToastStore();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const [isResetting, setIsResetting] = useState(false);
+
+  const handleReset = async () => {
+    setIsResetting(true);
+    try {
+      localStorage.removeItem("accent-color");
+      localStorage.removeItem("color-mode-preference");
+      setAccentColor("blue");
+      showToast({
+        id: "reset-settings",
+        title: "Settings reset",
+        status: "success",
+      });
+    } catch (err) {
+      console.error("Failed to reset settings:", err);
+      showToast({
+        id: "reset-settings-error",
+        title: "Failed to reset",
+        description: "An error occurred while resetting your settings.",
+        status: "error",
+      });
+    } finally {
+      setIsResetting(false);
+      onClose();
+    }
+  };
+
+  return (
+    <Flex direction="column" gap={4}>
+      <Card bg="transparent" variant="outline">
+        <CardHeader px={4} py={3}>
+          <Text fontWeight="semibold" fontSize="lg">
+            Advanced
+          </Text>
+        </CardHeader>
+        <Divider />
+        <CardBody p={4}>
+          <Flex direction="column" gap={4}>
+            <SettingRow
+              label="Reset Settings"
+              description="Restore all preferences to their default values."
+              control={
+                <Button colorScheme="red" onClick={onOpen}>
+                  Reset
+                </Button>
+              }
+            />
+          </Flex>
+        </CardBody>
+      </Card>
+
+      <AlertDialog
+        isOpen={isOpen}
+        leastDestructiveRef={cancelRef}
+        onClose={onClose}
+        isCentered
+      >
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader fontSize="lg" fontWeight="bold">
+              Reset Settings
+            </AlertDialogHeader>
+            <AlertDialogBody>
+              Are you sure you want to restore all settings to their default
+              values?
+            </AlertDialogBody>
+            <AlertDialogFooter>
+              <HStack gap={4}>
+                <Button
+                  variant="ghost"
+                  colorScheme="gray"
+                  onClick={onClose}
+                  ref={cancelRef}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="ghost"
+                  colorScheme="red"
+                  onClick={handleReset}
+                  isLoading={isResetting}
+                >
+                  Reset
+                </Button>
+              </HStack>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
+    </Flex>
+  );
+};
+
+export default Advanced;
+

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -30,6 +30,7 @@ import Appearance from "./Appearance";
 import General from "./General";
 import VoiceAndAccessibility from "./VoiceAndAccessibility";
 import DataAndPrivacy from "./DataAndPrivacy";
+import Advanced from "./Advanced";
 
 interface SettingsProps {
   isOpen: boolean;
@@ -206,7 +207,9 @@ const Settings: FC<SettingsProps> = ({ isOpen, onClose }) => {
                 <DataAndPrivacy />
               </TabPanel>
               <TabPanel>Account settings go here.</TabPanel>
-              <TabPanel>Advanced settings go here.</TabPanel>
+              <TabPanel>
+                <Advanced />
+              </TabPanel>
               <TabPanel>About info goes here.</TabPanel>
             </TabPanels>
           </Tabs>


### PR DESCRIPTION
## Summary
- add Advanced settings component with reset confirmation
- integrate Advanced component into Settings tabs

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7bd7ebd948327bada50ee198a2181