### PR TITLE
Ensure user records exist after login

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -365,7 +365,6 @@ const Home: FC = () => {
 
     if (user && isNewThread && id) {
       setThreadId(id);
-      await supabase.from("users").upsert({ id: user.id, user_id: user.id });
       await supabase.from("threads").insert({
         id,
         user_id: user.id,

--- a/src/stores/auth/useAuth.ts
+++ b/src/stores/auth/useAuth.ts
@@ -30,11 +30,11 @@ const useAuth = create<AuthState>((set) => ({
         }
 
         if (!userRow) {
-          const { error: insertUserError } = await supabase
+          const { error: upsertUserError } = await supabase
             .from("users")
-            .insert({ id: user.id, user_id: user.id });
-          if (insertUserError)
-            console.error("Error creating user record:", insertUserError);
+            .upsert({ id: user.id, user_id: user.id }, { onConflict: "id" });
+          if (upsertUserError)
+            console.error("Error creating user record:", upsertUserError);
         }
 
         const { data: prefRow, error: prefError } = await supabase
@@ -48,11 +48,11 @@ const useAuth = create<AuthState>((set) => ({
         }
 
         if (!prefRow) {
-          const { error: insertPrefError } = await supabase
+          const { error: upsertPrefError } = await supabase
             .from("user_preferences")
-            .insert({ user_id: user.id });
-          if (insertPrefError)
-            console.error("Error creating user preferences:", insertPrefError);
+            .upsert({ user_id: user.id }, { onConflict: "user_id" });
+          if (upsertPrefError)
+            console.error("Error creating user preferences:", upsertPrefError);
         }
       } catch (err) {
         console.error("Failed to ensure user records:", err);


### PR DESCRIPTION
## Summary
- Ensure a newly authenticated user has entries in `users` and `user_preferences`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba7e9e78388327bad81173a37e7e9e