### PR TITLE
Ensure user and preference records exist after login

### DIFF
--- a/src/components/AuthInitializer/index.tsx
+++ b/src/components/AuthInitializer/index.tsx
@@ -1,18 +1,47 @@
 "use client";
 
-import { ReactNode, useEffect } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { Progress } from "@themed-components";
+import { supabase } from "@/lib";
 import { useAuth } from "@/stores";
 
 const AuthInitializer = ({ children }: { children: ReactNode }) => {
-  const { loading, initializeAuth } = useAuth();
+  const { user, loading, initializeAuth } = useAuth();
+  const [ready, setReady] = useState(false);
 
   useEffect(() => {
     const unsubscribe = initializeAuth();
     return () => unsubscribe();
   }, [initializeAuth]);
 
-  return loading ? <Progress size="xs" isIndeterminate /> : children;
+  useEffect(() => {
+    const ensureRecords = async () => {
+      if (!loading && user) {
+        try {
+          await supabase
+            .from("users")
+            .upsert({ id: user.id, user_id: user.id });
+
+          await supabase
+            .from("user_preferences")
+            .upsert({ user_id: user.id }, { onConflict: "user_id" });
+        } catch (error) {
+          console.error("Failed to initialize user records:", error);
+        }
+      }
+      if (!loading) {
+        setReady(true);
+      }
+    };
+
+    ensureRecords();
+  }, [user, loading]);
+
+  if (loading || !ready) {
+    return <Progress size="xs" isIndeterminate />;
+  }
+
+  return children;
 };
 
 export default AuthInitializer;


### PR DESCRIPTION
## Summary
- Initialize database records for new users at login, creating `users` and `user_preferences` rows when missing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba7e9e78388327bad81173a37e7e9e