### PR TITLE
fix: reset color mode to system and update button

### DIFF
--- a/src/components/Settings/Advanced.tsx
+++ b/src/components/Settings/Advanced.tsx
@@ -81,7 +81,9 @@ const Advanced: FC = () => {
   const handleReset = async () => {
     setIsResetting(true);
     try {
-      setColorMode("system");
+      const systemPrefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      setColorMode(systemPrefersDark ? "dark" : "light");
+      localStorage.removeItem("chakra-ui-color-mode");
       localStorage.setItem("color-mode-preference", "system");
 
       setAccentColor("cyan");
@@ -180,9 +182,7 @@ const Advanced: FC = () => {
                   Cancel
                 </Button>
                 <Button
-                  variant="ghost"
                   colorScheme="red"
-                  leftIcon={<HiOutlineRefresh />}
                   onClick={handleReset}
                   isLoading={isResetting}
                 >


### PR DESCRIPTION
## Summary
- ensure resetting settings updates color mode to system preference instantly
- remove ghost variant and icon from confirm reset button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be672a475c832797316a91106a6f11