### PR TITLE
Ensure Advanced settings reset color mode immediately

### DIFF
--- a/src/components/Settings/Advanced.tsx
+++ b/src/components/Settings/Advanced.tsx
@@ -81,7 +81,10 @@ const Advanced: FC = () => {
   const handleReset = async () => {
     setIsResetting(true);
     try {
-      setColorMode("system");
+      const prefersDark = window.matchMedia(
+        "(prefers-color-scheme: dark)"
+      ).matches;
+      setColorMode(prefersDark ? "dark" : "light");
       localStorage.setItem("color-mode-preference", "system");
 
       setAccentColor("cyan");
@@ -180,9 +183,7 @@ const Advanced: FC = () => {
                   Cancel
                 </Button>
                 <Button
-                  variant="ghost"
                   colorScheme="red"
-                  leftIcon={<HiOutlineRefresh />}
                   onClick={handleReset}
                   isLoading={isResetting}
                 >


### PR DESCRIPTION
## Summary
- Match system preference on reset so color mode updates immediately
- Simplify reset confirmation button style

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be672a475c832797316a91106a6f11