### PR TITLE
Fix color mode resetting

### DIFF
--- a/src/components/Settings/Advanced.tsx
+++ b/src/components/Settings/Advanced.tsx
@@ -81,7 +81,12 @@ const Advanced: FC = () => {
   const handleReset = async () => {
     setIsResetting(true);
     try {
-      setColorMode("system");
+      const prefersDark =
+        typeof window !== "undefined" &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+      setColorMode(prefersDark ? "dark" : "light");
+      localStorage.removeItem("chakra-ui-color-mode");
       localStorage.setItem("color-mode-preference", "system");
 
       setAccentColor("cyan");
@@ -180,9 +185,7 @@ const Advanced: FC = () => {
                   Cancel
                 </Button>
                 <Button
-                  variant="ghost"
                   colorScheme="red"
-                  leftIcon={<HiOutlineRefresh />}
                   onClick={handleReset}
                   isLoading={isResetting}
                 >


### PR DESCRIPTION
## Summary
- ensure settings reset applies system color mode immediately
- simplify reset confirmation button styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be672a475c832797316a91106a6f11