### PR TITLE
feat: use menu for accent color selection

### DIFF
--- a/src/components/Settings/Appearance.tsx
+++ b/src/components/Settings/Appearance.tsx
@@ -9,32 +9,18 @@ import {
   Divider,
   Flex,
   Icon,
-  SimpleGrid,
   Text,
   Grid,
   useColorMode,
-  useColorModeValue,
-  useToken,
 } from "@chakra-ui/react";
 import { useAccentColor, useAuth } from "@/stores";
 import { ACCENT_COLORS, AccentColors } from "@/theme/types";
 import { supabase } from "@/lib";
 import { Menu } from "@/components/ui";
 import { RiSunLine, RiMoonLine, RiComputerLine } from "react-icons/ri";
-import { FaSquare } from "react-icons/fa6";
+import { FaSquare, FaCheckSquare } from "react-icons/fa";
 
 const MODE_STORAGE_KEY = "color-mode-preference";
-
-const SectionText = ({ title, desc }: { title: string; desc: string }) => (
-  <Box>
-    <Text fontSize="md" fontWeight="semibold">
-      {title}
-    </Text>
-    <Text mt={1} fontSize="xs" color="secondaryText">
-      {desc}
-    </Text>
-  </Box>
-);
 
 const SettingRow = ({
   label,
@@ -74,61 +60,6 @@ const SettingRow = ({
     </Flex>
   </Grid>
 );
-
-const AccentTile = ({
-  name,
-  colorKey,
-  isActive,
-  onClick,
-}: {
-  name: string;
-  colorKey: AccentColors | string;
-  isActive: boolean;
-  onClick: () => void;
-}) => {
-  const dotLight = `${colorKey}.600`;
-  const dotDark = `${colorKey}.200`;
-  const [swatchLight, swatchDark] = useToken("colors", [dotLight, dotDark]);
-  const activeRing = useColorModeValue(`${colorKey}.400`, `${colorKey}.300`);
-  const activeText = useColorModeValue(`${colorKey}.700`, `${colorKey}.200`);
-  const hoveredBg = useColorModeValue("gray.50", "whiteAlpha.100");
-  const activeBg = useColorModeValue("gray.100", "whiteAlpha.200");
-
-  return (
-    <Flex
-      as="button"
-      type="button"
-      role="radio"
-      aria-checked={isActive}
-      onClick={onClick}
-      px={3}
-      py={2.5}
-      gap={3}
-      align="center"
-      justify="space-between"
-      rounded="md"
-      borderWidth="1px"
-      borderColor={isActive ? activeRing : "border"}
-      bg={isActive ? activeBg : "transparent"}
-      _hover={{ bg: hoveredBg }}
-      _active={{ bg: activeBg }}
-      outline="0"
-      transition="all .15s ease"
-    >
-      <Flex align="center" gap={3} minW={0}>
-        <Icon
-          as={FaSquare}
-          boxSize={5}
-          color={useColorModeValue(swatchLight, swatchDark)}
-          flexShrink={0}
-        />
-        <Text noOfLines={1} color={isActive ? activeText : "inherit"}>
-          {name}
-        </Text>
-      </Flex>
-    </Flex>
-  );
-};
 
 const Appearance: FC = () => {
   const { setColorMode } = useColorMode();
@@ -203,7 +134,7 @@ const Appearance: FC = () => {
     if (error) console.error("Failed to save color mode:", error);
   };
 
-const saveAccent = async (value: AccentColors) => {
+  const saveAccent = async (value: AccentColors) => {
     setAccentColor(value);
     if (!user) return;
     const { error } = await supabase
@@ -270,29 +201,33 @@ const saveAccent = async (value: AccentColors) => {
             />
 
             <Divider />
-
-            <Flex direction="column" gap={3}>
-              <SectionText
-                title="Accent Color"
-                desc="Pick a highlight color for buttons, links, and emphasis."
-              />
-              <SimpleGrid
-                columns={{ base: 2, sm: 3, md: 4 }}
-                gap={2.5}
-                role="radiogroup"
-                aria-label="Accent color"
-              >
-                {Object.entries(ACCENT_COLORS).map(([key, { name }]) => (
-                  <AccentTile
-                    key={key}
-                    name={name}
-                    colorKey={key as AccentColors}
-                    isActive={accentColor === key}
-                    onClick={() => saveAccent(key as AccentColors)}
-                  />
-                ))}
-              </SimpleGrid>
-            </Flex>
+            <SettingRow
+              label="Accent Color"
+              description="Pick a highlight color for buttons, links, and emphasis."
+              control={
+                <Menu
+                  value={accentColor}
+                  onChange={(value) => {
+                    if (!value) return;
+                    saveAccent(value as AccentColors);
+                  }}
+                  items={Object.entries(ACCENT_COLORS).map(([key, { name }]) => ({
+                    value: key,
+                    label: name,
+                    icon: (
+                      <Icon
+                        as={accentColor === key ? FaCheckSquare : FaSquare}
+                        boxSize={4}
+                        color={`${key}.600`}
+                        _dark={{ color: `${key}.200` }}
+                      />
+                    ),
+                  }))}
+                  includeNullOption={false}
+                  buttonProps={{ variant: "outline" }}
+                />
+              }
+            />
           </Flex>
         </CardBody>
       </Card>

--- a/src/components/Settings/Appearance.tsx
+++ b/src/components/Settings/Appearance.tsx
@@ -40,12 +40,7 @@ const SettingRow = ({
     <Box minW={0}>
       <Text fontWeight="medium">{label}</Text>
       {description && (
-        <Text
-          mt={1}
-          fontSize="xs"
-          color="secondaryText"
-          wordBreak="break-word"
-        >
+        <Text mt={1} fontSize="xs" color="secondaryText" wordBreak="break-word">
           {description}
         </Text>
       )}
@@ -211,18 +206,20 @@ const Appearance: FC = () => {
                     if (!value) return;
                     saveAccent(value as AccentColors);
                   }}
-                  items={Object.entries(ACCENT_COLORS).map(([key, { name }]) => ({
-                    value: key,
-                    label: name,
-                    icon: (
-                      <Icon
-                        as={FaSquare}
-                        boxSize={4}
-                        color={`${key}.600`}
-                        _dark={{ color: `${key}.200` }}
-                      />
-                    ),
-                  }))}
+                  items={Object.entries(ACCENT_COLORS).map(
+                    ([key, { name }]) => ({
+                      value: key,
+                      label: name,
+                      icon: (
+                        <Icon
+                          as={FaSquare}
+                          boxSize={4}
+                          color={`${key}.600`}
+                          _dark={{ color: `${key}.200` }}
+                        />
+                      ),
+                    })
+                  )}
                   includeNullOption={false}
                   buttonProps={{ variant: "outline" }}
                 />

--- a/src/components/Settings/Appearance.tsx
+++ b/src/components/Settings/Appearance.tsx
@@ -18,7 +18,7 @@ import { ACCENT_COLORS, AccentColors } from "@/theme/types";
 import { supabase } from "@/lib";
 import { Menu } from "@/components/ui";
 import { RiSunLine, RiMoonLine, RiComputerLine } from "react-icons/ri";
-import { FaSquare, FaCheckSquare } from "react-icons/fa";
+import { FaSquare } from "react-icons/fa";
 
 const MODE_STORAGE_KEY = "color-mode-preference";
 
@@ -216,7 +216,7 @@ const Appearance: FC = () => {
                     label: name,
                     icon: (
                       <Icon
-                        as={accentColor === key ? FaCheckSquare : FaSquare}
+                        as={FaSquare}
                         boxSize={4}
                         color={`${key}.600`}
                         _dark={{ color: `${key}.200` }}

--- a/src/components/ui/Menu/index.tsx
+++ b/src/components/ui/Menu/index.tsx
@@ -12,7 +12,7 @@ import {
 } from "@chakra-ui/react";
 import type { ButtonProps } from "@chakra-ui/react";
 import { HiOutlineChevronDown } from "react-icons/hi";
-import { FaCheck } from "react-icons/fa";
+import { IoIosCheckmark } from "react-icons/io";
 import Button from "../Button";
 import MenuList from "../MenuList";
 import MenuItem from "../MenuItem";
@@ -84,7 +84,7 @@ const Menu = ({
           >
             <Flex align="center" justify="space-between" w="full">
               {placeholder}
-              {value === null && <Icon as={FaCheck} boxSize={4} />}
+              {value === null && <Icon as={IoIosCheckmark} boxSize={6} />}
             </Flex>
           </MenuItem>
         )}
@@ -98,7 +98,7 @@ const Menu = ({
           >
             <Flex align="center" justify="space-between" w="full">
               {item.label}
-              {item.value === value && <Icon as={FaCheck} boxSize={4} />}
+              {item.value === value && <Icon as={IoIosCheckmark} boxSize={6} />}
             </Flex>
           </MenuItem>
         ))}

--- a/src/components/ui/Menu/index.tsx
+++ b/src/components/ui/Menu/index.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useRef, type ReactElement } from "react";
+import { useRef, type ReactElement, type ReactNode } from "react";
 import {
   Box,
+  Flex,
+  Icon,
   Menu as ChakraMenu,
   MenuButton as ChakraMenuButton,
   type MenuProps as ChakraMenuProps,
@@ -10,13 +12,14 @@ import {
 } from "@chakra-ui/react";
 import type { ButtonProps } from "@chakra-ui/react";
 import { HiOutlineChevronDown } from "react-icons/hi";
+import { FaCheck } from "react-icons/fa";
 import Button from "../Button";
 import MenuList from "../MenuList";
 import MenuItem from "../MenuItem";
 import { useAccentColor } from "@/stores";
 
 interface MenuItemData {
-  label: string;
+  label: ReactNode;
   value: string;
   icon?: ReactElement;
 }
@@ -79,7 +82,10 @@ const Menu = ({
             onClick={() => onChange(null)}
             color={value === null ? selectedColor : undefined}
           >
-            {placeholder}
+            <Flex align="center" justify="space-between" w="full">
+              {placeholder}
+              {value === null && <Icon as={FaCheck} boxSize={4} />}
+            </Flex>
           </MenuItem>
         )}
         {items.map((item) => (
@@ -90,7 +96,10 @@ const Menu = ({
             color={item.value === value ? selectedColor : undefined}
             icon={item.icon}
           >
-            {item.label}
+            <Flex align="center" justify="space-between" w="full">
+              {item.label}
+              {item.value === value && <Icon as={FaCheck} boxSize={4} />}
+            </Flex>
           </MenuItem>
         ))}
       </MenuList>


### PR DESCRIPTION
## Summary
- replace accent color tiles with menu dropdown
- show color swatch icons and check mark for selected accent

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3a09c43c48327a994d4a1b569a1d6